### PR TITLE
feat: improve layout of protection/recovery request 

### DIFF
--- a/src/wallet-user/trust-protection/ProtectionRecoveryRequest.css
+++ b/src/wallet-user/trust-protection/ProtectionRecoveryRequest.css
@@ -31,6 +31,11 @@
     padding: 10px;
 }
 
+.ProtectionRecoveryRequest .Claim,
+.ProtectionRecoveryRequest .Activate {
+    margin-top: 15px;
+}
+
 .ProtectionRecoveryRequest .legal-officers {
     margin-top: 50px;
 }

--- a/src/wallet-user/trust-protection/ProtectionRecoveryRequest.tsx
+++ b/src/wallet-user/trust-protection/ProtectionRecoveryRequest.tsx
@@ -28,6 +28,7 @@ import './ProtectionRecoveryRequest.css';
 import { ProtectionRequestStatus } from '@logion/client/dist/RecoveryClient';
 import ProtectionRefusal from "./ProtectionRefusal";
 import RecoveryRefusal from "./RecoveryRefusal";
+import ButtonGroup from "../../common/ButtonGroup";
 
 export type ProtectionRecoveryRequestStatus = 'pending' | 'accepted' | 'activated' | 'unavailable' | 'rejected';
 
@@ -196,12 +197,14 @@ export default function ProtectionRecoveryRequest(props: Props) {
 
                         {
                             props.type === 'accepted' && !protectionParameters.isActive && activationCall === undefined &&
-                            <Button
-                                data-testid="btnActivate"
-                                onClick={ activateProtectionCallback }
-                            >
-                                Activate
-                            </Button>
+                            <ButtonGroup className="Activate">
+                                <Button
+                                    data-testid="btnActivate"
+                                    onClick={ activateProtectionCallback }
+                                >
+                                    Activate
+                                </Button>
+                            </ButtonGroup>
                         }
                         <ClientExtrinsicSubmitter
                             successMessage="Protection successfully activated."
@@ -209,12 +212,14 @@ export default function ProtectionRecoveryRequest(props: Props) {
                         />
                         {
                             props.type === 'activated' && protectionParameters.isRecovery && !protectionParameters.isClaimed && claimCall === undefined &&
-                            <Button
-                                data-testid="btnClaim"
-                                onClick={ claimRecoveryCallback }
-                            >
-                                Claim
-                            </Button>
+                            <ButtonGroup className="Claim">
+                                <Button
+                                    data-testid="btnClaim"
+                                    onClick={ claimRecoveryCallback }
+                                >
+                                    Claim
+                                </Button>
+                            </ButtonGroup>
                         }
                         <ClientExtrinsicSubmitter
                             successMessage="Recovery successfully initiated."

--- a/src/wallet-user/trust-protection/ProtectionRefusal.tsx
+++ b/src/wallet-user/trust-protection/ProtectionRefusal.tsx
@@ -8,13 +8,15 @@ import './ProtectionRefusal.css';
 import { RED } from "../../common/ColorTheme";
 import ButtonGroup from "../../common/ButtonGroup";
 import { LegalOfficerProtectionState } from "@logion/client/dist/Recovery";
+import { Refusal } from "./ProtectionRecoveryRequest";
 
 export interface Props {
     protection: RejectedProtection
+    refusal: Refusal
 }
 
 export default function ProtectionRefusal(props: Props) {
-    const { protection } = props;
+    const { protection, refusal } = props;
     const { cancelProtection, resubmitProtection, changeProtectionLegalOfficer } = useUserContext()
     const rejectedState = protection.protectionParameters.states[0];
     const currentLegalOfficer = rejectedState.legalOfficer;
@@ -27,8 +29,6 @@ export default function ProtectionRefusal(props: Props) {
         return null
     }
     const legalOfficers = availableLegalOfficers.filter(lo => lo.address !== currentLegalOfficer.address && lo.address !== otherLegalOfficer.address);
-    type Refusal = 'single' | 'double';
-    const refusal: Refusal = otherState.status === 'REJECTED' ? 'double' : 'single';
 
     function reasonBox(state: LegalOfficerProtectionState) {
         const legalOfficer = state.legalOfficer;
@@ -82,14 +82,6 @@ export default function ProtectionRefusal(props: Props) {
                 <>
                     <div>Or select another Legal Officer for your protection:</div>
                     <div className="select">
-                        <ButtonGroup>
-                            <Button
-                                disabled={ newLegalOfficer === null }
-                                onClick={ () => changeProtectionLegalOfficer(rejectedState.legalOfficer, newLegalOfficer!) }
-                            >
-                                Submit a new request
-                            </Button>
-                        </ButtonGroup>
                         <SelectLegalOfficer
                             legalOfficer={ newLegalOfficer }
                             legalOfficerNumber={ 3 }
@@ -99,6 +91,14 @@ export default function ProtectionRefusal(props: Props) {
                             setLegalOfficer={ setNewLegalOfficer }
                             label=""
                         />
+                        <ButtonGroup>
+                            <Button
+                                disabled={ newLegalOfficer === null }
+                                onClick={ () => changeProtectionLegalOfficer(rejectedState.legalOfficer, newLegalOfficer!) }
+                            >
+                                Submit a new request
+                            </Button>
+                        </ButtonGroup>
                     </div>
                 </>
             }

--- a/src/wallet-user/trust-protection/RecoveryRefusal.tsx
+++ b/src/wallet-user/trust-protection/RecoveryRefusal.tsx
@@ -6,13 +6,15 @@ import './RecoveryRefusal.css';
 import { RED } from "../../common/ColorTheme";
 import ButtonGroup from "../../common/ButtonGroup";
 import { LegalOfficerProtectionState } from "@logion/client/dist/Recovery";
+import { Refusal } from "./ProtectionRecoveryRequest";
 
 export interface Props {
     recovery: RejectedRecovery
+    refusal: Refusal
 }
 
 export default function RecoveryRefusal(props: Props) {
-    const { recovery } = props;
+    const { recovery, refusal } = props;
     const { cancelProtection, resubmitProtection } = useUserContext()
     const rejectedState = recovery.protectionParameters.states[0];
     const currentLegalOfficer = rejectedState.legalOfficer;
@@ -23,8 +25,6 @@ export default function RecoveryRefusal(props: Props) {
     if (!availableLegalOfficers) {
         return null
     }
-    type Refusal = 'single' | 'double';
-    const refusal: Refusal = otherState.status === 'REJECTED' ? 'double' : 'single';
 
     function reasonBox(state: LegalOfficerProtectionState) {
         const legalOfficer = state.legalOfficer;

--- a/src/wallet-user/trust-protection/__snapshots__/ProtectionRecoveryRequest.test.tsx.snap
+++ b/src/wallet-user/trust-protection/__snapshots__/ProtectionRecoveryRequest.test.tsx.snap
@@ -359,12 +359,16 @@ exports[`ProtectionRecoveryRequest activated recovery request 1`] = `
     <ClientExtrinsicSubmitter
       successMessage="Protection successfully activated."
     />
-    <Button
-      data-testid="btnClaim"
-      onClick={[Function]}
+    <ButtonGroup
+      className="Claim"
     >
-      Claim
-    </Button>
+      <Button
+        data-testid="btnClaim"
+        onClick={[Function]}
+      >
+        Claim
+      </Button>
+    </ButtonGroup>
     <ClientExtrinsicSubmitter
       successMessage="Recovery successfully initiated."
     />
@@ -1032,12 +1036,16 @@ exports[`ProtectionRecoveryRequest pending recovery request 1`] = `
     <ClientExtrinsicSubmitter
       successMessage="Protection successfully activated."
     />
-    <Button
-      data-testid="btnClaim"
-      onClick={[Function]}
+    <ButtonGroup
+      className="Claim"
     >
-      Claim
-    </Button>
+      <Button
+        data-testid="btnClaim"
+        onClick={[Function]}
+      >
+        Claim
+      </Button>
+    </ButtonGroup>
     <ClientExtrinsicSubmitter
       successMessage="Recovery successfully initiated."
     />


### PR DESCRIPTION
* Display the second LO in case of double refusal.
* Swap the button and drop box to select another LO.
* Center Activate and Claim buttons.

logion-network/logion-internal#500