### PR TITLE
Fix file names

### DIFF
--- a/src/__mocks__/@logion/client.ts
+++ b/src/__mocks__/@logion/client.ts
@@ -18,3 +18,5 @@ export {
     CheckResultType,
     ClosedCollectionLoc,
 }
+
+export { MimeType } from "@logion/client/dist/Mime";

--- a/src/common/ViewFileButton.tsx
+++ b/src/common/ViewFileButton.tsx
@@ -9,6 +9,7 @@ import './ViewFileButton.css';
 import { Children, customClassName } from "./types/Helpers";
 import { useLogionChain } from "../logion-chain";
 import { AxiosFactory } from "./api";
+import { MimeType } from "@logion/client";
 
 export interface FileInfo {
     fileName: string;
@@ -23,13 +24,26 @@ export interface ViewFileProps extends FileInfo {
 
 async function openFile(axios: AxiosInstance, props: ViewFileProps) {
     const file = await props.downloader(axios!);
+    const fileName = fixFileName(props.fileName, file.mimeType);
     const url = window.URL.createObjectURL(new Blob([ file.data ]));
     const link: HTMLAnchorElement = document.createElement('a');
     link.href = url;
     link.target = "_blank"
-    link.setAttribute('download', `${ props.fileName }.${ file.extension }`);
+    link.setAttribute('download', fileName);
     document.body.appendChild(link);
     link.click();
+}
+
+function fixFileName(fileName: string, mimeType: MimeType): string {
+    if(fileName.lastIndexOf(".") !== -1) {
+        const validExtensions = mimeType.extensions;
+        for(const extension of validExtensions) {
+            if(fileName.endsWith(`.${extension}`)) {
+                return fileName;
+            }
+        }
+    }
+    return `${fileName}.${mimeType.extensions[0]}`;
 }
 
 export default function ViewFileButton(props: ViewFileProps) {

--- a/src/loc/FileModel.test.ts
+++ b/src/loc/FileModel.test.ts
@@ -36,7 +36,7 @@ describe("FileModel", () => {
                 responseType: "blob"
             })
         );
-        expect(typedFile.extension).toBe("jpeg");
+        expect(typedFile.mimeType.extensions[0]).toBe("jpeg");
     })
 
     it("downloads LO file", async () => {
@@ -59,7 +59,7 @@ describe("FileModel", () => {
                 responseType: "blob"
             })
         );
-        expect(typedFile.extension).toBe("jpeg");
+        expect(typedFile.mimeType.extensions[0]).toBe("jpeg");
     })
 
     it("downloads collection item file", async () => {
@@ -86,7 +86,7 @@ describe("FileModel", () => {
                 responseType: "blob"
             })
         );
-        expect(typedFile.extension).toBe("jpeg");
+        expect(typedFile.mimeType.extensions[0]).toBe("jpeg");
     })
 
     it("downloads LOC as JSON", async () => {
@@ -109,7 +109,7 @@ describe("FileModel", () => {
                 responseType: "blob"
             })
         );
-        expect(typedFile.extension).toBe("json");
+        expect(typedFile.mimeType.extensions[0]).toBe("json");
     })
 
     it("adds LO file", async () => {

--- a/src/loc/FileModel.ts
+++ b/src/loc/FileModel.ts
@@ -1,5 +1,5 @@
 import { AxiosInstance, AxiosResponse } from "axios";
-import { LegalOfficer, Token } from "@logion/client";
+import { LegalOfficer, Token, MimeType } from "@logion/client";
 
 export const LO_FILE_IDS = [ 'oath-logo', 'header-logo', 'seal' ];
 
@@ -26,7 +26,7 @@ export interface GetCollectionItemFileParameters extends GetFileParameters {
 
 export interface TypedFile {
     data: any,
-    extension: string
+    mimeType: MimeType,
 }
 
 export async function getFile(
@@ -76,18 +76,10 @@ export async function getJsonLoc(
 
 function typedFile(response: AxiosResponse): TypedFile {
     const contentType: string = response.headers['content-type'];
-    return { data: response.data, extension: determineExtension(contentType) };
-}
-
-function determineExtension(contentType: string) {
-    if (!contentType || contentType.indexOf("/") < 0) {
-        return "txt"
-    }
-    const extension = contentType.split("/")[1];
-    if (extension.indexOf(";") > 0) {
-        return extension.split(";")[0];
-    }
-    return extension;
+    return {
+        data: response.data,
+        mimeType: MimeType.from(contentType),
+    };
 }
 
 export interface AddLoFileParameters {

--- a/src/loc/LocPrivateFileButton.tsx
+++ b/src/loc/LocPrivateFileButton.tsx
@@ -23,7 +23,7 @@ export function LocPrivateFileButton(props: Props) {
     const { addFile, locItems } = props;
     const { colorTheme } = useCommonContext();
     const [ status, setStatus ] = useState<Status>('Idle');
-    const { control, handleSubmit, formState: { errors }, reset } = useForm<FormValues>();
+    const { control, handleSubmit, formState: { errors }, reset, setValue } = useForm<FormValues>();
     const [ file, setFile ] = useState<File | null>(null);
     const [ existingItem, setExistingItem ] = useState<LocItem | null>(null);
     const [ duplicateHash, setDuplicateHash ] = useState<string | null>(null);
@@ -50,6 +50,11 @@ export function LocPrivateFileButton(props: Props) {
             }
         }
     }, [ file, addFile, locItems, setExistingItem ])
+
+    const handleSelectedFile = useCallback((file: File) => {
+        setFile(file);
+        setValue("fileName", file.name);
+    }, [ setValue ]);
 
     return (
         <>
@@ -85,7 +90,7 @@ export function LocPrivateFileButton(props: Props) {
                     control={ control }
                     errors={ errors }
                     colors={ colorTheme.dialog }
-                    onFileSelected={ setFile }
+                    onFileSelected={ handleSelectedFile }
                 />
                 { status === 'Uploading' &&
                     <Row>

--- a/src/loc/LocPrivateFileForm.tsx
+++ b/src/loc/LocPrivateFileForm.tsx
@@ -22,7 +22,14 @@ export default function LocPrivateFileForm(props: Props) {
         <>
             <h3>Add a confidential document</h3>
             <p>Important: after publication, the only data that will be publicly available on the blockchain will be the
-                HASH of the document and its nature (which can remain empty). The document name is not published.</p>
+                HASH of the document and its nature (which can remain empty). The document name is not published.
+            </p>
+            <FormGroup
+                id="locFile"
+                label="File"
+                control={ <FileSelectorButton onFileSelected={ props.onFileSelected } /> }
+                colors={ props.colors }
+            />
             <FormGroup
                 id="locFileName"
                 label="Document Name"
@@ -43,7 +50,8 @@ export default function LocPrivateFileForm(props: Props) {
                         ) } />
 
                 }
-                colors={ props.colors } />
+                colors={ props.colors }
+            />
             <FormGroup
                 id="locFileNature"
                 label="Document Public Description"
@@ -63,12 +71,8 @@ export default function LocPrivateFileForm(props: Props) {
                         ) } />
 
                 }
-                colors={ props.colors } />
-            <FormGroup
-                id="locFile"
-                label="File"
-                control={ <FileSelectorButton onFileSelected={ props.onFileSelected } /> }
-                colors={ props.colors } />
+                colors={ props.colors }
+            />
         </>
     )
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2922,14 +2922,14 @@ __metadata:
   linkType: hard
 
 "@logion/client@npm:^0.14.0-3":
-  version: 0.14.0-3
-  resolution: "@logion/client@npm:0.14.0-3"
+  version: 0.14.0-4
+  resolution: "@logion/client@npm:0.14.0-4"
   dependencies:
     "@logion/node-api": ^0.7.0-1
     axios: ^0.27.2
     luxon: ^3.0.1
     mime-db: ^1.52.0
-  checksum: ef641ff4a6182dcb2af25ceeb92a6c1bd5de10ff1a74814016de36eb13a95fa7f285f2fd94c7790b8890a0ace34d9daa3f84c08fbbce142d2366a6eed9e93a0e
+  checksum: a2dfee133d0087c155af72e1b59426f0de7f3a6a30ebd2d829b8b56842a537ebf7b5e5761cdd4dd6377c022695bf8f4b83805b5289b1ca36acac25f09665beca
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
* Uploaded file name is re-used as document name when adding a file to a LOC
* On file download/view, file name is conditionally fixed (i.e. only if original file name does not already end with a valid extension)

logion-network/logion-internal#613