### PR TITLE
Improve LOC context performance

### DIFF
--- a/src/legal-officer/LegalOfficerContext.tsx
+++ b/src/legal-officer/LegalOfficerContext.tsx
@@ -42,6 +42,7 @@ export interface MissingSettings {
 
 export interface LegalOfficerContext {
     refreshRequests: ((clearBeforeRefresh: boolean) => void),
+    locsState: LocsState | null,
     pendingProtectionRequests: ProtectionRequest[] | null,
     activatedProtectionRequests: ProtectionRequest[] | null,
     protectionRequestsHistory: ProtectionRequest[] | null,
@@ -82,6 +83,7 @@ function initialContextValue(): FullLegalOfficerContext {
     return {
         dataAddress: null,
         refreshRequests: DEFAULT_NOOP,
+        locsState: null,
         pendingProtectionRequests: null,
         activatedProtectionRequests: null,
         protectionRequestsHistory: null,
@@ -132,6 +134,7 @@ type ActionType =
 interface Action {
     type: ActionType;
     dataAddress?: string;
+    locsState?: LocsState;
     pendingProtectionRequests?: ProtectionRequest[];
     protectionRequestsHistory?: ProtectionRequest[];
     activatedProtectionRequests?: ProtectionRequest[];
@@ -190,6 +193,7 @@ const reducer: Reducer<FullLegalOfficerContext, Action> = (state: FullLegalOffic
             if (action.dataAddress === state.dataAddress) {
                 return {
                     ...state,
+                    locsState: action.locsState!,
                     pendingLocRequests: action.pendingLocRequests!,
                     rejectedLocRequests: action.rejectedLocRequests!,
                     openedLocRequests: action.openedLocRequests!,
@@ -645,6 +649,7 @@ function mapLocsState(locsState: LocsState) {
     }
 
     return {
+        locsState,
         pendingLocRequests,
         openedLocRequests,
         closedLocRequests,

--- a/src/legal-officer/__mocks__/LegalOfficerContextMock.tsx
+++ b/src/legal-officer/__mocks__/LegalOfficerContextMock.tsx
@@ -1,4 +1,4 @@
-import { ClosedCollectionLoc, ClosedLoc, OpenLoc, PendingRequest, RejectedRequest, VoidedLoc } from "@logion/client";
+import { ClosedCollectionLoc, ClosedLoc, OpenLoc, PendingRequest, RejectedRequest, VoidedLoc, LocsState } from "@logion/client";
 import { LocType, IdentityLocType } from "@logion/node-api/dist/Types";
 import { AxiosInstance } from "axios";
 import { COLOR_THEME, PATRICK } from "src/common/TestData";
@@ -129,6 +129,14 @@ let refreshLegalOfficer = jest.fn();
 
 let refreshOnchainSettings = jest.fn();
 
+let locsState: LocsState = {
+    findById: () => { throw new Error("not found") },
+} as unknown as LocsState;
+
+export function setLocsState(mock: LocsState) {
+    locsState = mock;
+}
+
 export function useLegalOfficerContext() {
     return {
         pendingTokenizationRequests,
@@ -154,5 +162,6 @@ export function useLegalOfficerContext() {
         legalOfficer,
         refreshLegalOfficer,
         refreshOnchainSettings,
+        locsState,
     };
 }

--- a/src/legal-officer/transaction-protection/PendingLocRequests.tsx
+++ b/src/legal-officer/transaction-protection/PendingLocRequests.tsx
@@ -12,6 +12,7 @@ import { useLegalOfficerContext } from "../LegalOfficerContext";
 import { useResponsiveContext } from "../../common/Responsive";
 import { locDetailsPath } from "../LegalOfficerPaths";
 import { useNavigate } from 'react-router-dom';
+import { useMemo } from "react";
 
 export interface Props {
     locType: LocType;
@@ -22,6 +23,8 @@ export default function PendingLocRequests(props: Props) {
     const { locType } = props;
     const { width } = useResponsiveContext();
     const navigate = useNavigate();
+
+    const data = useMemo(() => pendingLocRequests ? pendingLocRequests[locType].map(loc => loc.data()) : [], [ pendingLocRequests, locType ]);
 
     if (pendingLocRequests === null) {
         return null;
@@ -73,7 +76,7 @@ export default function PendingLocRequests(props: Props) {
                         width: "150px",
                     }
                 ]}
-                data={ pendingLocRequests[locType].map(loc => loc.data()) }
+                data={ data }
                 renderEmpty={ () => <EmptyTableMessage>No pending LOC request</EmptyTableMessage> }
             />
         </>

--- a/src/loc/AcceptRejectLocRequest.test.tsx
+++ b/src/loc/AcceptRejectLocRequest.test.tsx
@@ -11,6 +11,7 @@ import { setRejectLocRequest } from "./__mocks__/ModelMock";
 
 jest.mock("../logion-chain");
 jest.mock('./Model');
+jest.mock("./LocContext");
 
 describe("AcceptRejectLocRequest", () => {
 
@@ -24,7 +25,7 @@ describe("AcceptRejectLocRequest", () => {
             ownerAddress: "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
             requesterAddress: "5Ew3MyB15VprZrjQVkpQFj8okmc9xLDSEdNhqMMS5cXsqxoW",
             status: "REQUESTED"
-        } as LocData} />);
+        } as LocData} rejectPath="/" />);
         expect(tree).toMatchSnapshot();
     });
 
@@ -37,7 +38,7 @@ describe("AcceptRejectLocRequest", () => {
             ownerAddress: "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
             requesterAddress: "5Ew3MyB15VprZrjQVkpQFj8okmc9xLDSEdNhqMMS5cXsqxoW",
             status: "REQUESTED"
-        } as LocData} />);
+        } as LocData} rejectPath="/" />);
         const rejectButton = screen.getByTestId(`reject-${REQUEST_ID}`);
         await userEvent.click(rejectButton);
 
@@ -68,7 +69,7 @@ describe("AcceptRejectLocRequest", () => {
             bars: 1,
             status: "PENDING",
             locType: "Transaction"
-        } as unknown as LocData} />);
+        } as unknown as LocData} rejectPath="/" />);
 
         const acceptButton = tree.getByTestId(`accept-${REQUEST_ID}`);
         await userEvent.click(acceptButton);

--- a/src/loc/AcceptRejectLocRequest.tsx
+++ b/src/loc/AcceptRejectLocRequest.tsx
@@ -1,9 +1,10 @@
 import { LocData } from "@logion/client";
 import { useCallback, useState } from "react";
 import { Form } from "react-bootstrap";
+import { useNavigate } from "react-router-dom";
+
 import Button from "src/common/Button";
 import ButtonGroup from "src/common/ButtonGroup";
-import { useCommonContext } from "src/common/CommonContext";
 import Icon from "src/common/Icon";
 import PolkadotFrame from "src/common/PolkadotFrame";
 import ProcessStep from "src/legal-officer/ProcessStep";
@@ -16,15 +17,16 @@ import "./AcceptRejectLocRequest.css";
 
 export interface Props {
     loc: LocData;
+    rejectPath: string;
 }
 
 export default function AcceptRejectLocRequest(props: Props) {
     const { axiosFactory, accounts } = useLogionChain();
-    const { refresh } = useCommonContext();
     const [ requestToReject, setRequestToReject ] = useState<string | null>(null);
     const [ reason, setReason ] = useState<string>("");
     const [ requestToAccept, setRequestToAccept ] = useState<LocData | null>(null);
     const { refresh: refreshLoc } = useLocContext();
+    const navigate = useNavigate();
 
     const clearRequestToAccept = useCallback(() => {
         refreshLoc();
@@ -42,9 +44,8 @@ export default function AcceptRejectLocRequest(props: Props) {
             requestId: requestToReject!,
             rejectReason: reason!,
         });
-        refresh(false);
-        refreshLoc();
-        setRequestToReject(null);
+        await refreshLoc();
+        navigate(props.rejectPath);
     };
 
     return (

--- a/src/loc/CloseLocButton.tsx
+++ b/src/loc/CloseLocButton.tsx
@@ -49,7 +49,7 @@ export default function CloseLocButton(props: Props) {
     const { accounts, axiosFactory, api } = useLogionChain();
     const { refresh } = useCommonContext();
     const { refreshRequests, refreshLocs } = useLegalOfficerContext();
-    const { closeExtrinsic, close, locItems, locId } = useLocContext();
+    const { closeExtrinsic, close, locItems, loc } = useLocContext();
     const [ closeState, setCloseState ] = useState<CloseState>({ status: CloseStatus.NONE });
     const [ signAndSubmit, setSignAndSubmit ] = useState<SignAndSubmit>(null);
     const [ disabled, setDisabled ] = useState<boolean>(false);
@@ -119,13 +119,13 @@ export default function CloseLocButton(props: Props) {
     }, [ setCloseState, props.protectionRequest, accounts, api, close, refresh, refreshLocs, alreadyVouched ]);
 
     useEffect(() => {
-        if (closeState.status === CloseStatus.ACCEPTING) {
+        if (closeState.status === CloseStatus.ACCEPTING && loc) {
             setCloseState({ status: CloseStatus.NONE });
             (async function() {
                 const currentAddress = accounts!.current!.address;
                 await acceptProtectionRequest(axiosFactory!(currentAddress)!, {
                     requestId: props.protectionRequest!.id,
-                    locId: locId!
+                    locId: loc.id,
                 });
                 close!();
                 refresh!(false);
@@ -139,7 +139,11 @@ export default function CloseLocButton(props: Props) {
                 }
             })();
         }
-    }, [ closeState, setCloseState, accounts, axiosFactory, close, locId, navigate, props.protectionRequest, refresh, refreshRequests, refreshLocs ]);
+    }, [ closeState, setCloseState, accounts, axiosFactory, close, loc, navigate, props.protectionRequest, refresh, refreshRequests, refreshLocs ]);
+
+    if(!loc) {
+        return null;
+    }
 
     let closeButtonText;
     let firstStatus: CloseStatus;
@@ -187,7 +191,7 @@ export default function CloseLocButton(props: Props) {
                     }
                 ]}
             >
-                <p>You are about to close the identity LOC (ID: { locId.toDecimalString() }) you created with regard to a request for protection.</p>
+                <p>You are about to close the identity LOC (ID: { loc.id.toDecimalString() }) you created with regard to a request for protection.</p>
                 <p>By clicking on "Confirm" below, you will definitively accept to protect the account of the following person:</p>
 
                 <Row>

--- a/src/loc/ContextualizedLocDetails.tsx
+++ b/src/loc/ContextualizedLocDetails.tsx
@@ -15,6 +15,7 @@ import LegalOfficerInstructions from "./LegalOfficerInstructions";
 import SupersedesDisclaimer from "./SupersedesDisclaimer";
 import VoidFrame from "./VoidFrame";
 import AcceptRejectLocRequest from "./AcceptRejectLocRequest";
+import { locRequestsPath } from "src/legal-officer/LegalOfficerPaths";
 
 export default function ContextualizedLocDetails() {
     const { pendingProtectionRequests, pendingRecoveryRequests } = useLegalOfficerContext();
@@ -108,6 +109,7 @@ export default function ContextualizedLocDetails() {
                 loc.status === "REQUESTED" &&
                 <AcceptRejectLocRequest
                     loc={ loc }
+                    rejectPath={ locRequestsPath(loc.locType) }
                 />
             }
             { loc.locType === 'Collection' && loc.closed &&

--- a/src/loc/DashboardCertificate.tsx
+++ b/src/loc/DashboardCertificate.tsx
@@ -20,7 +20,6 @@ export default function DashboardCertificate() {
     const itemId = useParams<"itemId">().itemId;
     const {
         backPath,
-        locId,
         loc,
         collectionItems,
     } = useLocContext();
@@ -34,11 +33,11 @@ export default function DashboardCertificate() {
     useEffect(() => {
         if(loc && itemId && deliveries === undefined) {
             (async function() {
-                const deliveries = await getAllDeliveries(axiosFactory!(loc?.ownerAddress), { locId: locId.toString(), collectionItemId: itemId });
+                const deliveries = await getAllDeliveries(axiosFactory!(loc?.ownerAddress), { locId: loc.id.toString(), collectionItemId: itemId });
                 setDeliveries(deliveries);
             })();
         }
-    }, [ collectionItem, axiosFactory, itemId, locId, loc, deliveries ]);
+    }, [ collectionItem, axiosFactory, itemId, loc, deliveries ]);
 
     const checkHash = useCallback((hash: string) => {
         if (collectionItem) {

--- a/src/loc/LegalOfficerLocContext.test.tsx
+++ b/src/loc/LegalOfficerLocContext.test.tsx
@@ -1,4 +1,6 @@
+import { LocData, LocRequestState, LocsState } from "@logion/client";
 import { UUID } from "@logion/node-api";
+import { setLocsState } from "src/legal-officer/__mocks__/LegalOfficerContextMock";
 import { shallowRender } from "src/tests"
 import { LegalOfficerLocContextProvider, useLegalOfficerLocContext } from "./LegalOfficerLocContext";
 import { useLocContext } from "./LocContext";
@@ -8,6 +10,13 @@ jest.mock("../legal-officer/LegalOfficerContext");
 describe("LegalOfficerLocContextProvider", () => {
 
     it("renders", () => {
+        setLocsState({
+            findById: () => ({
+                data: () => ({
+                    id: locId,
+                } as unknown as LocData)
+            } as unknown as LocRequestState)
+        } as unknown as LocsState);
         const element = shallowRender(<LegalOfficerLocContextProvider
             locId={ locId }
             backPath="/"

--- a/src/loc/LegalOfficerLocContext.tsx
+++ b/src/loc/LegalOfficerLocContext.tsx
@@ -27,15 +27,15 @@ export function fetchAllLocsParams(legalOfficer: LegalOfficer): FetchAllLocsPara
 };
 
 export function LegalOfficerLocContextProvider(props: Props) {
-    const { refreshLocs, legalOfficer } = useLegalOfficerContext();
+    const { refreshLocs, legalOfficer, locsState } = useLegalOfficerContext();
 
-    if(!legalOfficer) {
+    if(!legalOfficer || !locsState) {
         return null;
     }
 
     return (
         <LocContextProvider
-            locId={ props.locId }
+            locState={ locsState.findById(props.locId) }
             backPath={ props.backPath }
             detailsPath={ props.detailsPath }
             refreshLocs={ async (newLocsState?: LocsState) => refreshLocs(newLocsState) }

--- a/src/loc/UserLocContext.test.tsx
+++ b/src/loc/UserLocContext.test.tsx
@@ -1,5 +1,7 @@
 import { UUID } from "@logion/node-api";
+import { LocData, LocRequestState, LocsState } from "@logion/client";
 import { shallowRender } from "src/tests";
+import { setLocsState } from "src/wallet-user/__mocks__/UserContextMock";
 import { useLocContext } from "./LocContext";
 import { UserLocContextProvider, useUserLocContext } from "./UserLocContext";
 
@@ -8,6 +10,13 @@ jest.mock("../wallet-user/UserContext");
 describe("UserLocContextProvider", () => {
 
     it("renders", () => {
+        setLocsState({
+            findById: () => ({
+                data: () => ({
+                    id: locId,
+                } as unknown as LocData)
+            } as unknown as LocRequestState)
+        } as unknown as LocsState);
         const element = shallowRender(<UserLocContextProvider
             locId={ locId }
             backPath="/"

--- a/src/loc/UserLocContext.tsx
+++ b/src/loc/UserLocContext.tsx
@@ -16,12 +16,16 @@ export interface Props {
 export function UserLocContextProvider(props: Props) {
     const { mutateLocsState, locsState } = useUserContext();
 
+    if(!locsState) {
+        return null;
+    }
+
     return (
         <LocContextProvider
-            locId={ props.locId }
+            locState={ locsState.findById(props.locId) }
             backPath={ props.backPath }
             detailsPath={ props.detailsPath }
-            refreshLocs={ (newLocsState?: LocsState) => newLocsState ? mutateLocsState(() => Promise.resolve(newLocsState)) : mutateLocsState(async () => await locsState!.refresh()) }
+            refreshLocs={ (newLocsState: LocsState) => mutateLocsState(async () => newLocsState) }
         >
             { props.children }
         </LocContextProvider>

--- a/src/loc/__snapshots__/LegalOfficerLocContext.test.tsx.snap
+++ b/src/loc/__snapshots__/LegalOfficerLocContext.test.tsx.snap
@@ -45,26 +45,9 @@ exports[`LegalOfficerLocContextProvider renders 1`] = `
       },
     }
   }
-  locId={
-    UUID {
-      "bytes": Uint8Array [
-        39,
-        76,
-        18,
-        115,
-        93,
-        14,
-        76,
-        129,
-        188,
-        228,
-        161,
-        85,
-        24,
-        175,
-        253,
-        53,
-      ],
+  locState={
+    Object {
+      "data": [Function],
     }
   }
   refreshLocs={[Function]}

--- a/src/loc/__snapshots__/UserLocContext.test.tsx.snap
+++ b/src/loc/__snapshots__/UserLocContext.test.tsx.snap
@@ -4,26 +4,9 @@ exports[`UserLocContextProvider renders 1`] = `
 <LocContextProvider
   backPath="/"
   detailsPath={[Function]}
-  locId={
-    UUID {
-      "bytes": Uint8Array [
-        39,
-        76,
-        18,
-        115,
-        93,
-        14,
-        76,
-        129,
-        188,
-        228,
-        161,
-        85,
-        24,
-        175,
-        253,
-        53,
-      ],
+  locState={
+    Object {
+      "data": [Function],
     }
   }
   refreshLocs={[Function]}

--- a/src/loc/archive/ArchiveButton.tsx
+++ b/src/loc/archive/ArchiveButton.tsx
@@ -32,23 +32,23 @@ export default function ArchiveButton() {
 
     type Status = 'Idle' | 'Selected' | 'Checked';
     const [ status, setStatus ] = useState<Status>('Idle');
-    const { locItems, loc: locData, locId } = useLocContext();
+    const { locItems, loc: locData } = useLocContext();
     const { axiosFactory } = useLogionChain();
-
-    const backup: TypedFileInfo = {
-        fileName: `${ locId.toString() }`,
-        downloader: (axios: AxiosInstance) => getJsonLoc(axios, { locId: locId.toString() }),
-        type: "JSON Backup file"
-    }
-
-    const files: TypedFileInfo[] = [ backup ].concat(
-        locItems
-            .filter(locItem => locItem.type === 'Document')
-            .map(locItem => documentToTypedFileInfo(locId, locItem)))
 
     if (!locData || !axiosFactory) {
         return null;
     }
+
+    const backup: TypedFileInfo = {
+        fileName: `${ locData.id.toString() }`,
+        downloader: (axios: AxiosInstance) => getJsonLoc(axios, { locId: locData.id.toString() }),
+        type: "JSON Backup file"
+    };
+
+    const files: TypedFileInfo[] = [ backup ].concat(
+        locItems
+            .filter(locItem => locItem.type === 'Document')
+            .map(locItem => documentToTypedFileInfo(locData.id, locItem)));
 
     return (
         <>

--- a/src/loc/statement/StatementOfFactsButton.tsx
+++ b/src/loc/statement/StatementOfFactsButton.tsx
@@ -27,7 +27,7 @@ type Status = 'IDLE' | 'PRE-REQUISITE' | 'INPUT' | 'READY'
 
 export default function StatementOfFactsButton(props: { item?: CollectionItem }) {
     const { api, accounts, getOfficer } = useLogionChain();
-    const { locId, loc: locData } = useLocContext();
+    const { loc: locData } = useLocContext();
     const { settings } = useLegalOfficerContext();
     const [ sofParams, setSofParams ] = useState<SofParams>(DEFAULT_SOF_PARAMS);
     const [ item, setItem ] = useState<CollectionItem>();
@@ -46,7 +46,7 @@ export default function StatementOfFactsButton(props: { item?: CollectionItem })
                 setError("containingLocId", { type: "value", message: "Invalid LOC ID" })
                 return
             }
-            if (containingLocId.toString() === locId.toString()) {
+            if (containingLocId.toString() === locData!.id.toString()) {
                 setError("containingLocId", { type: "value", message: "Choose a different LOC to upload Statement of Facts" })
                 return
             }
@@ -88,7 +88,7 @@ export default function StatementOfFactsButton(props: { item?: CollectionItem })
                 }
             }
         }
-    }, [ api, sofParams, setContainingLoc, setError, locId, language, accounts, legalOfficer, settings ])
+    }, [ api, sofParams, setContainingLoc, setError, locData, language, accounts, legalOfficer, settings ])
 
     const dropDownItem = (language: Language) => {
         return (
@@ -127,11 +127,11 @@ export default function StatementOfFactsButton(props: { item?: CollectionItem })
     }, [ getOfficer, accounts, sofParams, setSofParams ]);
 
     useEffect(() => {
-        if (locId.toDecimalString() !== sofParams.locId) {
+        if (locData!.id.toDecimalString() !== sofParams.locId) {
             const requester = locData?.requesterAddress ? locData.requesterAddress : locData?.requesterLocId?.toDecimalString() || ""
             setSofParams({
                 ...sofParams,
-                locId: locId.toDecimalString(),
+                locId: locData!.id.toDecimalString(),
                 requester,
                 publicItems: locData!.metadata.map(item => ({
                     description: item.name,
@@ -146,7 +146,7 @@ export default function StatementOfFactsButton(props: { item?: CollectionItem })
                 })),
             });
         }
-    }, [ locData, locId, sofParams, setSofParams ]);
+    }, [ locData, sofParams, setSofParams ]);
 
     useEffect(() => {
         if (language !== null && ((props.item && !item) || (!props.item && item) || (props.item && item && props.item.id !== item.id))) {
@@ -177,7 +177,7 @@ export default function StatementOfFactsButton(props: { item?: CollectionItem })
                 }
             )
         }
-    }, [ props, item, setItem, sofParams, setSofParams, locId, language ]);
+    }, [ props, item, setItem, sofParams, setSofParams, locData, language ]);
 
     const cancelCallback = useCallback(() => {
         setStatus('IDLE')
@@ -197,7 +197,7 @@ export default function StatementOfFactsButton(props: { item?: CollectionItem })
         setStatus('INPUT');
     }, [ sofParams ])
 
-    if(settings === undefined) {
+    if(settings === undefined || !locData) {
         return null;
     }
 
@@ -270,8 +270,8 @@ export default function StatementOfFactsButton(props: { item?: CollectionItem })
                 <StatementOfFactsSummary
                     previewPath={ STATEMENT_OF_FACTS_PATH }
                     relatedLocPath={ containingLoc ? locDetailsPath(containingLoc!.id, containingLoc!.locType) : "" }
-                    locId={ locId }
-                    nodeOwner={ locData!.ownerAddress }
+                    locId={ locData!.id }
+                    nodeOwner={ locData.ownerAddress }
                 />
             </Dialog>
         </>

--- a/src/loc/statement/StatementOfFactsRequestButton.tsx
+++ b/src/loc/statement/StatementOfFactsRequestButton.tsx
@@ -2,28 +2,24 @@ import Button from "../../common/Button";
 import { useUserLocContext } from "../UserLocContext";
 import { useState, useCallback } from "react";
 import Dialog from "../../common/Dialog";
-import { useCommonContext } from "../../common/CommonContext";
 import { locRequestsPath } from "../../wallet-user/UserRouter";
 
 type Status = 'Idle' | 'Confirming' | 'Requesting' | 'Requested';
 
 export default function StatementOfFactsRequestButton(props: { itemId?: string }) {
-
     const { itemId } = props;
     const { requestSof, requestSofOnCollection } = useUserLocContext();
-    const { refresh } = useCommonContext()
     const [ status, setStatus ] = useState<Status>('Idle')
 
-    const confirmCallback = useCallback(() => {
+    const confirmCallback = useCallback(async () => {
         setStatus('Requesting')
         if (itemId) {
-            requestSofOnCollection!(itemId);
+            await requestSofOnCollection!(itemId);
         } else {
-            requestSof!();
+            await requestSof!();
         }
-        refresh(false);
         setStatus('Requested');
-    }, [ itemId, refresh, requestSof, requestSofOnCollection ])
+    }, [ itemId, requestSof, requestSofOnCollection ])
 
     return (
         <>

--- a/src/wallet-user/__mocks__/UserContextMock.tsx
+++ b/src/wallet-user/__mocks__/UserContextMock.tsx
@@ -60,7 +60,7 @@ export function setRecoveredBalanceState(state: BalanceState | undefined) {
 
 export let mutateRecoveredBalanceState = jest.fn().mockReturnValue(Promise.resolve());
 
-export let locsState: Partial<LocsState>;
+export let locsState: Partial<LocsState> = {};
 
 export function setOpenedLocRequests(requests: any[]) {
     locsState = {

--- a/src/wallet-user/transaction-protection/DraftLocs.tsx
+++ b/src/wallet-user/transaction-protection/DraftLocs.tsx
@@ -21,7 +21,7 @@ export default function DraftLocs(props: Props) {
     const navigate = useNavigate();
     const { locType } = props;
 
-    const data = useMemo(() => locsState?.draftRequests[locType].map(locState => locState.data()) || [], [ locsState, locType ]);
+    const data = useMemo(() => locsState?.draftRequests ? locsState?.draftRequests[locType].map(locState => locState.data()) : [], [ locsState, locType ]);
 
     if(locsState === null || locsState?.draftRequests === undefined) {
         return <Loader />;

--- a/src/wallet-user/transaction-protection/RejectedLocs.tsx
+++ b/src/wallet-user/transaction-protection/RejectedLocs.tsx
@@ -16,7 +16,7 @@ export default function RejectedLocs(props: Props) {
     const { locsState } = useUserContext()
     const { locType } = props
 
-    const data = useMemo(() => locsState?.rejectedRequests[locType].map(locState => locState.data()) || [], [ locsState, locType ]);
+    const data = useMemo(() => locsState?.rejectedRequests ? locsState?.rejectedRequests[locType].map(locState => locState.data()) : [], [ locsState, locType ]);
 
     if(locsState === null || locsState?.rejectedRequests === undefined) {
         return <Loader />;

--- a/src/wallet-user/transaction-protection/RequestedLocs.tsx
+++ b/src/wallet-user/transaction-protection/RequestedLocs.tsx
@@ -16,7 +16,7 @@ export default function RequestedLocs(props: Props) {
     const { locsState } = useUserContext()
     const { locType } = props
 
-    const data = useMemo(() => locsState?.pendingRequests[locType].map(locState => locState.data()) || [], [ locsState, locType ]);
+    const data = useMemo(() => locsState?.pendingRequests ? locsState?.pendingRequests[locType].map(locState => locState.data()) : [], [ locsState, locType ]);
 
     if(locsState === null || locsState?.pendingRequests === undefined) {
         return <Loader />;


### PR DESCRIPTION
* `LocContext` now receives a `LocRequestState` which enables to minimize the number of HTTP requests on state transitions (no more useless fetches as `LocsState` is updated by SDK without the need for an explicit resync with backend and chain)
* Resync is still forced when clicking on main-menu items