### PR TITLE
Simplify LOC context

### DIFF
--- a/src/__mocks__/@logion/client.ts
+++ b/src/__mocks__/@logion/client.ts
@@ -8,6 +8,7 @@ import {
     fromIsoString,
     ClosedCollectionLoc,
     DraftRequest,
+    EditableRequest,
 } from '../LogionClientMock';
 
 export {
@@ -19,6 +20,7 @@ export {
     CheckResultType,
     ClosedCollectionLoc,
     DraftRequest,
+    EditableRequest,
 }
 
 export { MimeType } from "@logion/client/dist/Mime";

--- a/src/__mocks__/LogionClientMock.ts
+++ b/src/__mocks__/LogionClientMock.ts
@@ -3,6 +3,10 @@ import { PATRICK } from "../common/TestData";
 import { TEST_WALLET_USER } from "../wallet-user/TestData";
 export { toIsoString, fromIsoString } from "@logion/client/dist/DateTimeUtil";
 
+export const axiosMock = {
+    post: jest.fn().mockReturnValue(undefined),
+};
+
 export class LogionClient {
 
     static create() {
@@ -47,6 +51,10 @@ export class LogionClient {
 
     authenticate() {
         return this;
+    }
+
+    buildAxios() {
+        return axiosMock;
     }
 }
 

--- a/src/__mocks__/LogionClientMock.ts
+++ b/src/__mocks__/LogionClientMock.ts
@@ -105,9 +105,9 @@ export class EditableRequest extends LocRequestState {
     locsState: any;
     refresh: (() => Promise<EditableRequest>) | undefined;
     addMetadata: jest.Mock<Promise<EditableRequest>> | undefined;
-    deleteMetadata: jest.Mock | undefined;
+    deleteMetadata: jest.Mock<Promise<EditableRequest>> | undefined;
     addFile: jest.Mock<Promise<EditableRequest>> | undefined;
-    deleteFile: jest.Mock | undefined;
+    deleteFile: jest.Mock<Promise<EditableRequest>> | undefined;
 }
 
 export class DraftRequest extends EditableRequest {

--- a/src/__mocks__/LogionClientMock.ts
+++ b/src/__mocks__/LogionClientMock.ts
@@ -84,10 +84,24 @@ export function setIsSuccessful(value: boolean) {
     _isSuccessful = value;
 }
 
-export class ClosedCollectionLoc {
+export class LocRequestState {
+    
+}
+
+export class ClosedCollectionLoc extends LocRequestState {
 
 }
 
-export class DraftRequest {
+export class EditableRequest extends LocRequestState {
+    data: any;
+    locsState: any;
+    refresh: (() => Promise<EditableRequest>) | undefined;
+    addMetadata: jest.Mock | undefined;
+    deleteMetadata: jest.Mock | undefined;
+    addFile: jest.Mock | undefined;
+    deleteFile: jest.Mock | undefined;
+}
+
+export class DraftRequest extends EditableRequest {
 
 }

--- a/src/__mocks__/LogionClientMock.ts
+++ b/src/__mocks__/LogionClientMock.ts
@@ -96,9 +96,9 @@ export class EditableRequest extends LocRequestState {
     data: any;
     locsState: any;
     refresh: (() => Promise<EditableRequest>) | undefined;
-    addMetadata: jest.Mock | undefined;
+    addMetadata: jest.Mock<Promise<EditableRequest>> | undefined;
     deleteMetadata: jest.Mock | undefined;
-    addFile: jest.Mock | undefined;
+    addFile: jest.Mock<Promise<EditableRequest>> | undefined;
     deleteFile: jest.Mock | undefined;
 }
 

--- a/src/legal-officer/client.test.ts
+++ b/src/legal-officer/client.test.ts
@@ -1,0 +1,43 @@
+import { EditableRequest, LogionClient } from "@logion/client";
+import { UUID } from "@logion/node-api";
+import { AxiosInstance } from "axios";
+import { addLink } from "./client";
+
+describe("Legal Officer client", () => {
+
+    it("adds link to LOC", async () => {
+        const axios = {
+            post: jest.fn().mockResolvedValue(undefined),
+        } as unknown as AxiosInstance;
+
+        const client = {
+            buildAxios: () => axios,
+            legalOfficers: [],
+        } as unknown as LogionClient;
+
+        const locId = new UUID("0e16421a-2550-4be5-a6a8-1ab2239b7dc4");
+        const locState = {
+            data: () => ({
+                id: locId,
+            }),
+            refresh: () => Promise.resolve(locState),
+        } as EditableRequest;
+
+        const nature = "Some link";
+        const target = new UUID("8f12876b-7fde-49b0-93a4-d29ed5179151");
+        await addLink({
+            client,
+            locState,
+            target,
+            nature,
+        });
+
+        expect(axios.post).toBeCalledWith(
+            `/api/loc-request/${locId.toString()}/links`,
+            expect.objectContaining({
+                nature,
+                target: target.toString(),
+            })
+        )
+    })
+});

--- a/src/legal-officer/client.ts
+++ b/src/legal-officer/client.ts
@@ -1,0 +1,14 @@
+import { LogionClient, EditableRequest } from "@logion/client";
+import { UUID } from "@logion/node-api";
+
+export async function addLink(params: {
+    client: LogionClient,
+    locState: EditableRequest,
+    target: UUID,
+    nature: string,
+}): Promise<EditableRequest> {
+    const { client, locState, target, nature } = params;
+    const axios = client.buildAxios(client.legalOfficers.find(legalOfficer => locState.data().ownerAddress === legalOfficer.address)!);
+    await axios.post(`/api/loc-request/${ locState.data().id.toString() }/links`, { target: target.toString(), nature })
+    return await locState.refresh() as EditableRequest;
+}

--- a/src/loc/ContextualizedLocDetails.tsx
+++ b/src/loc/ContextualizedLocDetails.tsx
@@ -30,7 +30,6 @@ export default function ContextualizedLocDetails() {
         deleteMetadata,
         deleteFile,
         deleteLink,
-        addMetadata,
         addFile,
         checkHash,
         checkResult,
@@ -85,7 +84,6 @@ export default function ContextualizedLocDetails() {
                 locState={ locState }
                 locItems={ locItems }
                 addFile={ addFile }
-                addMetadata={ addMetadata }
                 checkResult={ checkResult }
                 deleteFile={ deleteFile }
                 deleteLink={ deleteLink }

--- a/src/loc/ContextualizedLocDetails.tsx
+++ b/src/loc/ContextualizedLocDetails.tsx
@@ -28,7 +28,6 @@ export default function ContextualizedLocDetails() {
         supersededLoc,
         locItems,
         deleteMetadata,
-        deleteFile,
         deleteLink,
         checkHash,
         checkResult,
@@ -83,7 +82,6 @@ export default function ContextualizedLocDetails() {
                 locState={ locState }
                 locItems={ locItems }
                 checkResult={ checkResult }
-                deleteFile={ deleteFile }
                 deleteLink={ deleteLink }
                 deleteMetadata={ deleteMetadata }
                 viewer="LegalOfficer"

--- a/src/loc/ContextualizedLocDetails.tsx
+++ b/src/loc/ContextualizedLocDetails.tsx
@@ -30,7 +30,6 @@ export default function ContextualizedLocDetails() {
         deleteMetadata,
         deleteFile,
         deleteLink,
-        addFile,
         checkHash,
         checkResult,
         collectionItem,
@@ -83,7 +82,6 @@ export default function ContextualizedLocDetails() {
                 loc={ loc }
                 locState={ locState }
                 locItems={ locItems }
-                addFile={ addFile }
                 checkResult={ checkResult }
                 deleteFile={ deleteFile }
                 deleteLink={ deleteLink }

--- a/src/loc/LegalOfficerLocContext.tsx
+++ b/src/loc/LegalOfficerLocContext.tsx
@@ -6,7 +6,7 @@ import {
 import { useLegalOfficerContext } from "../legal-officer/LegalOfficerContext";
 import { LocContextProvider, useLocContext } from "./LocContext";
 
-export type { FullVoidInfo, LinkTarget } from "./LocContext";
+export type { FullVoidInfo } from "./LocContext";
 
 export interface Props {
     locId: UUID

--- a/src/loc/LocContext.test.tsx
+++ b/src/loc/LocContext.test.tsx
@@ -187,25 +187,30 @@ async function thenReaderDisplaysLocRequestAndItems() {
 }
 
 function ItemAdder() {
-    const { locItems, addFile, addLink, locState, mutateLocState } = useLocContext();
+    const { locItems, addLink, locState, mutateLocState } = useLocContext();
 
     const callback = useCallback(async () => {
         await mutateLocState(async (current) => {
-            console.log(current)
             if(current instanceof EditableRequest) {
-                return current.addMetadata!({
+                let next: EditableRequest;
+                next = await current.addMetadata!({
                     name: "New data",
                     value: "value"
                 });
+                next = await current.addFile!({
+                    file: new File([], "file.png"),
+                    name: "New file",
+                    nature: "Some nature",
+                });
+                return next as unknown as LocRequestState;
             } else {
                 return current;
             }
         });
-        addFile!("New file", new File([], "file.png"), "Some nature");
         addLink!(_linkedLocData, "Some nature");
-    }, [ mutateLocState, addFile, addLink ]);
+    }, [ mutateLocState, addLink ]);
 
-    if(!addFile || !addLink || !locState) {
+    if(!addLink || !locState) {
         return null;
     }
 

--- a/src/loc/LocContext.test.tsx
+++ b/src/loc/LocContext.test.tsx
@@ -394,15 +394,23 @@ async function thenItemsPublished(confirmFunction: jest.Mock) {
 }
 
 function ItemDeleter() {
-    const { locItems, deleteMetadata, deleteFile, deleteLink } = useLocContext();
+    const { locItems, deleteMetadata, deleteLink, mutateLocState } = useLocContext();
 
-    const callback = useCallback(() => {
+    const callback = useCallback(async () => {
+        await mutateLocState(async current => {
+            if(current instanceof EditableRequest) {
+                return current.deleteFile!({
+                    hash: "new-hash",
+                }) as unknown as RealEditableRequest;
+            } else {
+                return current;
+            }
+        });
         deleteMetadata!(locItems.find(item => item.name === "New data")!);
-        deleteFile!(locItems.find(item => item.name === "New file")!);
         deleteLink!(locItems.find(item => item.nature === "New link")!);
-    }, [ locItems, deleteMetadata, deleteFile, deleteLink ]);
+    }, [ locItems, deleteMetadata, deleteLink ]);
 
-    if(!deleteMetadata || !deleteFile || !deleteLink) {
+    if(!deleteMetadata || !deleteLink) {
         return null;
     }
 

--- a/src/loc/LocContext.tsx
+++ b/src/loc/LocContext.tsx
@@ -56,7 +56,6 @@ export interface LocContext {
     supersededLoc?: PublicLoc
     locState: LocRequestState | null
     locItems: LocItem[]
-    deleteFile: ((locItem: LocItem) => void) | null
     deleteMetadata: ((locItem: LocItem) => void) | null
     backPath: string
     detailsPath: (locId: UUID, type: LocType) => string
@@ -99,7 +98,6 @@ function initialContextValue(locState: LocRequestState | null, backPath: string,
         close: null,
         closeExtrinsic: null,
         confirmFile: null,
-        deleteFile: null,
         confirmLink: null,
         deleteLink: null,
         confirmMetadata: null,
@@ -133,7 +131,6 @@ type ActionType = 'SET_LOC_REQUEST'
     | 'SET_CLOSE'
     | 'SET_CLOSE_EXTRINSIC'
     | 'SET_CONFIRM_FILE'
-    | 'SET_DELETE_FILE'
     | 'SET_CONFIRM_LINK'
     | 'SET_DELETE_LINK'
     | 'SET_CONFIRM_METADATA'
@@ -164,7 +161,6 @@ interface Action {
     close?: () => void,
     closeExtrinsic?: (seal?: string) => SignAndSubmit,
     confirmFile?: (locItem: LocItem) => void,
-    deleteFile?: (locItem: LocItem) => void,
     confirmLink?: (locItem: LocItem) => void
     deleteLink?: (locItem: LocItem) => void,
     confirmMetadata?: (locItem: LocItem) => void,
@@ -259,11 +255,6 @@ const reducer: Reducer<LocContext, Action> = (state: LocContext, action: Action)
             return {
                 ...state,
                 confirmFile: action.confirmFile!,
-            }
-        case 'SET_DELETE_FILE':
-            return {
-                ...state,
-                deleteFile: action.deleteFile!,
             }
         case 'SET_CONFIRM_LINK':
             return {
@@ -628,19 +619,6 @@ export function LocContextProvider(props: Props) {
             })
         }
     }, [ contextValue.confirmFile, confirmFileFunction ]);
-
-    const deleteFileFunction = useCallback(async (item: LocItem) => {
-        await dispatchLocAndItems(await (contextValue.locState as OpenLoc).deleteFile({ hash: item.value }), true)
-    }, [ dispatchLocAndItems, contextValue.locState ])
-
-    useEffect(() => {
-        if(contextValue.deleteFile !== deleteFileFunction) {
-            dispatch({
-                type: "SET_DELETE_FILE",
-                deleteFile: deleteFileFunction,
-            })
-        }
-    }, [ contextValue.deleteFile, deleteFileFunction ]);
 
     const confirmLinkFunction = useCallback(async (locItem: LocItem) => {
         await confirmLocLink(axiosFactory!(contextValue.loc!.ownerAddress)!, contextValue.loc!.id, locItem.target!);

--- a/src/loc/LocContext.tsx
+++ b/src/loc/LocContext.tsx
@@ -63,7 +63,6 @@ export interface LocContext {
     supersededLoc?: PublicLoc
     locState: LocRequestState | null
     locItems: LocItem[]
-    addFile: ((name: string, file: File, nature: string) => Promise<void>) | null
     deleteFile: ((locItem: LocItem) => void) | null
     deleteMetadata: ((locItem: LocItem) => void) | null
     backPath: string
@@ -105,7 +104,6 @@ function initialContextValue(locState: LocRequestState | null, backPath: string,
         addLink: null,
         publishLink: null,
         publishMetadata: null,
-        addFile: null,
         publishFile: null,
         close: null,
         closeExtrinsic: null,
@@ -141,7 +139,6 @@ type ActionType = 'SET_LOC_REQUEST'
     | 'SET_PUBLIC_LINK'
     | 'SET_ADD_LINK'
     | 'SET_PUBLISH_LINK'
-    | 'SET_ADD_FILE'
     | 'SET_PUBLISH_FILE'
     | 'SET_CLOSE'
     | 'SET_CLOSE_EXTRINSIC'
@@ -174,7 +171,6 @@ interface Action {
     addLink?: (otherLoc: LinkTarget, nature: string) => void,
     publishLink?: (locItem: LocItem) => SignAndSubmit,
     publishMetadata?: (locItem: LocItem) => SignAndSubmit,
-    addFile?: (name: string, file: File, nature: string) => Promise<void>,
     publishFile?: (locItem: LocItem) => SignAndSubmit,
     close?: () => void,
     closeExtrinsic?: (seal?: string) => SignAndSubmit,
@@ -259,11 +255,6 @@ const reducer: Reducer<LocContext, Action> = (state: LocContext, action: Action)
             return {
                 ...state,
                 publishLink: action.publishLink!,
-            }
-        case 'SET_ADD_FILE':
-            return {
-                ...state,
-                addFile: action.addFile!,
             }
         case 'SET_PUBLISH_FILE':
             return {
@@ -777,24 +768,6 @@ export function LocContextProvider(props: Props) {
             })
         }
     }, [ contextValue.addLink, addLinkFunction ]);
-
-    const addFileFunction = useCallback(async (name: string, file: File, nature: string) => {
-        const state = await (contextValue.locState as OpenLoc).addFile({
-            file,
-            fileName: name,
-            nature
-        });
-        await dispatchLocAndItems(state, true);
-    }, [ contextValue.locState, dispatchLocAndItems ])
-
-    useEffect(() => {
-        if(contextValue.addFile !== addFileFunction) {
-            dispatch({
-                type: "SET_ADD_FILE",
-                addFile: addFileFunction,
-            })
-        }
-    }, [ contextValue.addFile, addFileFunction ]);
 
     const refreshFunction = useCallback(async () => {
         await refreshLocState(true);

--- a/src/loc/LocCreationDialog.tsx
+++ b/src/loc/LocCreationDialog.tsx
@@ -1,5 +1,5 @@
 import { LocRequest } from "@logion/client";
-import { UUID } from "@logion/node-api";
+import { UUID, LocType } from "@logion/node-api";
 import { useCallback, useState } from 'react';
 import { useForm } from 'react-hook-form';
 
@@ -12,7 +12,12 @@ import LocCreationSteps from "./LocCreationSteps";
 import { useLegalOfficerContext } from '../legal-officer/LegalOfficerContext';
 import Alert from '../common/Alert';
 import { useLogionChain } from '../logion-chain';
-import { LinkTarget } from "./LocContext";
+
+export interface LinkTarget {
+    id: UUID;
+    description: string;
+    locType: LocType;
+}
 
 export interface Props {
     show: boolean,

--- a/src/loc/LocDetailsTab.test.tsx
+++ b/src/loc/LocDetailsTab.test.tsx
@@ -5,6 +5,9 @@ import { Viewer } from "src/common/CommonContext";
 import { CheckResult } from "src/components/checkfileframe/CheckFileFrame";
 import { shallowRender } from "src/tests";
 import LocDetailsTab, { LocDetailsTabContent } from "./LocDetailsTab";
+import { setLocRequest, setLocState } from "./__mocks__/LocContextMock";
+
+jest.mock("./LocContext");
 
 describe("LocDetailsTab", () => {
 
@@ -198,9 +201,9 @@ function buildLocMock(params: MockParameters): { loc: LocData, locState: LocRequ
 
 function testRenderContent(params: TestParameters) {
     const { loc, locState } = buildLocMock(params);
+    setLocRequest(loc);
+    setLocState(locState);
     const element = shallowRender(<LocDetailsTabContent
-        loc={ loc }
-        locState={ locState }
         viewer={ params.viewer }
         locTabBorderColor={ "black" }
         { ...otherProps }

--- a/src/loc/LocDetailsTab.tsx
+++ b/src/loc/LocDetailsTab.tsx
@@ -35,7 +35,6 @@ export interface Props {
     legalOfficer?: LegalOfficer;
     checkResult: DocumentCheckResult;
     locItems: LocItem[];
-    deleteFile: ((locItem: LocItem) => void) | null;
     deleteMetadata: ((locItem: LocItem) => void) | null;
     deleteLink: ((locItem: LocItem) => void) | null;
     protectionRequest?: ProtectionRequest | null;
@@ -109,14 +108,10 @@ export default function LocDetailsTab(props: Props) {
 }
 
 export interface ContentProps {
-    loc: LocData;
-    locState: LocRequestState;
     viewer: Viewer;
     detailsPath: (locId: UUID, type: LocType) => string;
     legalOfficer?: LegalOfficer;
     checkResult: DocumentCheckResult;
-    locItems: LocItem[];
-    deleteFile: ((locItem: LocItem) => void) | null;
     deleteMetadata: ((locItem: LocItem) => void) | null;
     deleteLink: ((locItem: LocItem) => void) | null;
     protectionRequest?: ProtectionRequest | null;
@@ -125,14 +120,10 @@ export interface ContentProps {
 
 export function LocDetailsTabContent(props: ContentProps) {
     const {
-        loc,
-        locState,
         viewer,
         detailsPath,
         legalOfficer,
         checkResult,
-        locItems,
-        deleteFile,
         deleteMetadata,
         deleteLink,
         protectionRequest,
@@ -140,7 +131,7 @@ export function LocDetailsTabContent(props: ContentProps) {
     } = props;
     const [ showCancelDialog, setShowCancelDialog ] = useState(false);
     const [ showSubmitDialog, setShowSubmitDialog ] = useState(false);
-    const { cancelRequest, backPath, submitRequest } = useLocContext();
+    const { loc, locState, cancelRequest, backPath, submitRequest } = useLocContext();
     const navigate = useNavigate();
 
     const confirmCancel = useCallback(() => {
@@ -160,6 +151,10 @@ export function LocDetailsTabContent(props: ContentProps) {
         await submitRequest();
         navigate(backPath);
     }, [ submitRequest, navigate, backPath ]);
+
+    if(!loc || !locState) {
+        return null;
+    }
 
     return (<>
         <Row>
@@ -207,12 +202,8 @@ export function LocDetailsTabContent(props: ContentProps) {
         <LocItems
             matchedHash={ checkResult.hash }
             viewer={ props.viewer }
-            locId={ loc.id }
-            locItems={ locItems }
             deleteMetadata={ deleteMetadata }
-            deleteFile={ deleteFile }
             deleteLink={ deleteLink }
-            loc={ loc }
         />
         {
             !loc.closed && loc.voidInfo === undefined &&

--- a/src/loc/LocDetailsTab.tsx
+++ b/src/loc/LocDetailsTab.tsx
@@ -35,7 +35,6 @@ export interface Props {
     legalOfficer?: LegalOfficer;
     checkResult: DocumentCheckResult;
     locItems: LocItem[];
-    addMetadata: ((name: string, value: string) => void) | null;
     addFile: ((name: string, file: File, nature: string) => Promise<void>) | null;
     deleteFile: ((locItem: LocItem) => void) | null;
     deleteMetadata: ((locItem: LocItem) => void) | null;
@@ -118,7 +117,6 @@ export interface ContentProps {
     legalOfficer?: LegalOfficer;
     checkResult: DocumentCheckResult;
     locItems: LocItem[];
-    addMetadata: ((name: string, value: string) => void) | null;
     addFile: ((name: string, file: File, nature: string) => Promise<void>) | null;
     deleteFile: ((locItem: LocItem) => void) | null;
     deleteMetadata: ((locItem: LocItem) => void) | null;
@@ -136,7 +134,6 @@ export function LocDetailsTabContent(props: ContentProps) {
         legalOfficer,
         checkResult,
         locItems,
-        addMetadata,
         addFile,
         deleteFile,
         deleteMetadata,
@@ -230,10 +227,7 @@ export function LocDetailsTabContent(props: ContentProps) {
                             || (viewer === "LegalOfficer" && loc.status === "OPEN")
                         ) &&
                         <ButtonGroup align="left">
-                            <LocPublicDataButton
-                                locItems={ locItems }
-                                addMetadata={ addMetadata }
-                            />
+                            <LocPublicDataButton />
                             <LocPrivateFileButton
                                 locItems={ locItems }
                                 addFile={ addFile }

--- a/src/loc/LocDetailsTab.tsx
+++ b/src/loc/LocDetailsTab.tsx
@@ -35,7 +35,6 @@ export interface Props {
     legalOfficer?: LegalOfficer;
     checkResult: DocumentCheckResult;
     locItems: LocItem[];
-    addFile: ((name: string, file: File, nature: string) => Promise<void>) | null;
     deleteFile: ((locItem: LocItem) => void) | null;
     deleteMetadata: ((locItem: LocItem) => void) | null;
     deleteLink: ((locItem: LocItem) => void) | null;
@@ -117,7 +116,6 @@ export interface ContentProps {
     legalOfficer?: LegalOfficer;
     checkResult: DocumentCheckResult;
     locItems: LocItem[];
-    addFile: ((name: string, file: File, nature: string) => Promise<void>) | null;
     deleteFile: ((locItem: LocItem) => void) | null;
     deleteMetadata: ((locItem: LocItem) => void) | null;
     deleteLink: ((locItem: LocItem) => void) | null;
@@ -134,7 +132,6 @@ export function LocDetailsTabContent(props: ContentProps) {
         legalOfficer,
         checkResult,
         locItems,
-        addFile,
         deleteFile,
         deleteMetadata,
         deleteLink,
@@ -228,10 +225,7 @@ export function LocDetailsTabContent(props: ContentProps) {
                         ) &&
                         <ButtonGroup align="left">
                             <LocPublicDataButton />
-                            <LocPrivateFileButton
-                                locItems={ locItems }
-                                addFile={ addFile }
-                            />
+                            <LocPrivateFileButton />
                         </ButtonGroup>
                     }
                 </Col>

--- a/src/loc/LocItems.test.tsx
+++ b/src/loc/LocItems.test.tsx
@@ -12,9 +12,12 @@ import { accounts, DEFAULT_LEGAL_OFFICER_ACCOUNT, setCurrentAddress } from "src/
 import { Account } from "src/common/types/Accounts";
 import { DateTime } from "luxon";
 import { DEFAULT_LEGAL_OFFICER } from "src/common/TestData";
+import { setLocItems, setLocRequest, setLocState } from "./__mocks__/LocContextMock";
+import { EditableRequest } from "src/__mocks__/LogionClientMock";
 
 jest.mock("../common/CommonContext");
 jest.mock("../logion-chain");
+jest.mock("./LocContext");
 
 describe("LOLocItems", () => {
 
@@ -23,19 +26,15 @@ describe("LOLocItems", () => {
         setCurrentAddress(DEFAULT_LEGAL_OFFICER_ACCOUNT);
     });
 
-    const deleteFile = jest.fn();
     const deleteLink = jest.fn();
     const deleteMetadata = jest.fn();
 
     it("renders empty list", () => {
-        const loc = givenOpenLoc();
+        givenOpenLoc();
+        setLocItems([]);
         testRendersEmptyList(<LocItems
-            deleteFile={ deleteFile }
             deleteLink={ deleteLink }
             deleteMetadata={ deleteMetadata }
-            loc={ loc }
-            locId={ loc.id }
-            locItems={ [] }
             viewer="LegalOfficer"
         />);
     });
@@ -43,13 +42,10 @@ describe("LOLocItems", () => {
     it("renders with single draft item", () => {
         const loc = givenOpenLoc();
         const items = givenMetadataItem(loc, "DRAFT");
+        setLocItems(items);
         testRendersSingleDraftItem(<LocItems
-            deleteFile={ deleteFile }
             deleteLink={ deleteLink }
             deleteMetadata={ deleteMetadata }
-            loc={ loc }
-            locId={ loc.id }
-            locItems={ items }
             viewer="LegalOfficer"
         />);
     });
@@ -57,13 +53,10 @@ describe("LOLocItems", () => {
     it("deletes draft metadata item", async () => {
         const loc = givenOpenLoc();
         const items = givenMetadataItem(loc, "DRAFT");
+        setLocItems(items);
         await testDeletesDraftMetadataItem(<LocItems
-            deleteFile={ deleteFile }
             deleteLink={ deleteLink }
             deleteMetadata={ deleteMetadata }
-            loc={ loc }
-            locId={ loc.id }
-            locItems={ items }
             viewer="LegalOfficer"
         />, deleteMetadata);
     });
@@ -71,13 +64,10 @@ describe("LOLocItems", () => {
     it("cannot delete non-draft metadata item", async () => {
         const loc = givenOpenLoc();
         const items = givenMetadataItem(loc, "PUBLISHED");
+        setLocItems(items);
         await testCannotDeleteNonDraftMetadataItem(<LocItems
-            deleteFile={ deleteFile }
             deleteLink={ deleteLink }
             deleteMetadata={ deleteMetadata }
-            loc={ loc }
-            locId={ loc.id }
-            locItems={ items }
             viewer="LegalOfficer"
         />);
     });
@@ -85,27 +75,21 @@ describe("LOLocItems", () => {
     it("deletes draft file item", async () => {
         const loc = givenOpenLoc();
         const items = givenFileItem(loc, "DRAFT");
+        setLocItems(items);
         await testDeletesDraftFileItem(<LocItems
-            deleteFile={ deleteFile }
             deleteLink={ deleteLink }
             deleteMetadata={ deleteMetadata }
-            loc={ loc }
-            locId={ loc.id }
-            locItems={ items }
             viewer="LegalOfficer"
-        />, deleteFile);
+        />);
     });
 
     it("cannot delete non-draft file item", async () => {
         const loc = givenOpenLoc();
         const items = givenFileItem(loc, "PUBLISHED");
+        setLocItems(items);
         await testCannotDeleteNonDraftFileItem(<LocItems
-            deleteFile={ deleteFile }
             deleteLink={ deleteLink }
             deleteMetadata={ deleteMetadata }
-            loc={ loc }
-            locId={ loc.id }
-            locItems={ items }
             viewer="LegalOfficer"
         />);
     });
@@ -113,13 +97,10 @@ describe("LOLocItems", () => {
     it("deletes draft link item", async () => {
         const loc = givenOpenLoc();
         const items = givenLinkItem(loc, "DRAFT");
+        setLocItems(items);
         await testDeletesDraftLinkItem(<LocItems
-            deleteFile={ deleteFile }
             deleteLink={ deleteLink }
             deleteMetadata={ deleteMetadata }
-            loc={ loc }
-            locId={ loc.id }
-            locItems={ items }
             viewer="LegalOfficer"
         />, deleteLink);
     });
@@ -127,13 +108,10 @@ describe("LOLocItems", () => {
     it("cannot delete non-draft link item", async () => {
         const loc = givenOpenLoc();
         const items = givenLinkItem(loc, "PUBLISHED");
+        setLocItems(items);
         await testCannotDeleteNonDraftLinkItem(<LocItems
-            deleteFile={ deleteFile }
             deleteLink={ deleteLink }
             deleteMetadata={ deleteMetadata }
-            loc={ loc }
-            locId={ loc.id }
-            locItems={ items }
             viewer="LegalOfficer"
         />);
     });
@@ -150,14 +128,11 @@ describe("UserLocItems", () => {
     const deleteMetadata = jest.fn();
 
     it("renders empty list", () => {
-        const loc = givenOpenLoc();
+        givenOpenLoc();
+        setLocItems([]);
         testRendersEmptyList(<LocItems
-            deleteFile={ deleteFile }
             deleteLink={ null }
             deleteMetadata={ deleteMetadata }
-            loc={ loc }
-            locId={ loc.id }
-            locItems={ [] }
             viewer="User"
         />);
     });
@@ -165,13 +140,10 @@ describe("UserLocItems", () => {
     it("renders with single draft item", () => {
         const loc = givenOpenLoc();
         const items = givenMetadataItem(loc, "DRAFT");
+        setLocItems(items);
         testRendersSingleDraftItem(<LocItems
-            deleteFile={ deleteFile }
             deleteLink={ null }
             deleteMetadata={ deleteMetadata }
-            loc={ loc }
-            locId={ loc.id }
-            locItems={ items }
             viewer="User"
         />);
     });
@@ -179,13 +151,10 @@ describe("UserLocItems", () => {
     it("deletes draft metadata item", async () => {
         const loc = givenOpenLoc();
         const items = givenMetadataItem(loc, "DRAFT");
+        setLocItems(items);
         await testDeletesDraftMetadataItem(<LocItems
-            deleteFile={ deleteFile }
             deleteLink={ null }
             deleteMetadata={ deleteMetadata }
-            loc={ loc }
-            locId={ loc.id }
-            locItems={ items }
             viewer="User"
         />, deleteMetadata);
     });
@@ -193,13 +162,10 @@ describe("UserLocItems", () => {
     it("cannot delete non-draft metadata item", async () => {
         const loc = givenOpenLoc();
         const items = givenMetadataItem(loc, "PUBLISHED");
+        setLocItems(items);
         await testCannotDeleteNonDraftMetadataItem(<LocItems
-            deleteFile={ deleteFile }
             deleteLink={ null }
             deleteMetadata={ deleteMetadata }
-            loc={ loc }
-            locId={ loc.id }
-            locItems={ items }
             viewer="User"
         />);
     });
@@ -207,27 +173,21 @@ describe("UserLocItems", () => {
     it("deletes draft file item", async () => {
         const loc = givenOpenLoc();
         const items = givenFileItem(loc, "DRAFT");
+        setLocItems(items);
         await testDeletesDraftFileItem(<LocItems
-            deleteFile={ deleteFile }
             deleteLink={ null }
             deleteMetadata={ deleteMetadata }
-            loc={ loc }
-            locId={ loc.id }
-            locItems={ items }
             viewer="User"
-        />, deleteFile);
+        />);
     });
 
     it("cannot delete non-draft file item", async () => {
         const loc = givenOpenLoc();
         const items = givenFileItem(loc, "PUBLISHED");
+        setLocItems(items);
         await testCannotDeleteNonDraftFileItem(<LocItems
-            deleteFile={ deleteFile }
             deleteLink={ null }
             deleteMetadata={ deleteMetadata }
-            loc={ loc }
-            locId={ loc.id }
-            locItems={ items }
             viewer="User"
         />);
     });
@@ -269,8 +229,14 @@ async function testCannotDeleteNonDraftMetadataItem(component: React.ReactElemen
 function givenOpenLoc() {
     const uuid = UUID.fromDecimalString(OPEN_IDENTITY_LOC_ID)!;
     const request = buildLocRequest(uuid, OPEN_IDENTITY_LOC);
+    setLocRequest(request);
+    _locState = new EditableRequest();
+    _locState.deleteFile = jest.fn().mockResolvedValue(_locState);
+    setLocState(_locState);
     return request;
 }
+
+let _locState: EditableRequest;
 
 function givenMetadataItem(request: LocData, status: LocItemStatus): LocItem[] {
     request.metadata.push({
@@ -291,10 +257,10 @@ function givenMetadataItem(request: LocData, status: LocItemStatus): LocItem[] {
     }];
 }
 
-async function testDeletesDraftFileItem(component: React.ReactElement, deleteFile: jest.Mock) {
+async function testDeletesDraftFileItem(component: React.ReactElement) {
     renderTesting(component);
     await clickByName(deleteButtonName);
-    await waitFor(() => expect(deleteFile).toBeCalled());
+    await waitFor(() => expect(_locState.deleteFile).toBeCalled());
 }
 
 async function testCannotDeleteNonDraftFileItem(component: React.ReactElement) {

--- a/src/loc/LocLinkExistingLocDialog.tsx
+++ b/src/loc/LocLinkExistingLocDialog.tsx
@@ -1,11 +1,13 @@
-import { useForm } from "react-hook-form";
 import { UUID, getLegalOfficerCase } from "@logion/node-api";
+import { EditableRequest } from "@logion/client";
+import { useCallback } from "react";
+import { useForm } from "react-hook-form";
 
 import { useLogionChain } from "../logion-chain";
 import Dialog from "../common/Dialog";
 import LocLinkExistingForm, { FormValues } from "./LocLinkExistingForm";
-import { useCallback } from "react";
 import { useLocContext } from "./LocContext";
+import { addLink } from "src/legal-officer/client";
 
 export interface Props {
     show: boolean,
@@ -14,7 +16,7 @@ export interface Props {
 
 export default function LocLinkExistingDialog(props: Props) {
     const { api, client } = useLogionChain();
-    const { addLink, locItems } = useLocContext();
+    const { mutateLocState, locItems } = useLocContext();
     const { control, handleSubmit, setError, clearErrors, formState: { errors }, reset } = useForm<FormValues>({
         defaultValues: {
             locId: ""
@@ -38,12 +40,23 @@ export default function LocLinkExistingDialog(props: Props) {
             setError("locId", { type: "value", message: "LOC already linked" })
             return
         }
-        const locState = (await client!.locsState()).findById(locId);
-        const locData = locState!.data();
-        addLink!(locData, formValues.linkNature)
+
+        await mutateLocState(async current => {
+            if(client && current instanceof EditableRequest) {
+                const locData = current.locsState().findById(locId).data();
+                return await addLink({
+                    client,
+                    locState: current,
+                    target: locData.id,
+                    nature: formValues.linkNature,
+                });
+            } else {
+                return current;
+            }
+        });
         reset();
         props.exit();
-    }, [ props, addLink, locItems, api, setError, clearErrors, reset, client ])
+    }, [ props, locItems, api, setError, clearErrors, reset, client, mutateLocState ])
 
     return (
         <>

--- a/src/loc/LocPrivateFileButton.test.tsx
+++ b/src/loc/LocPrivateFileButton.test.tsx
@@ -3,8 +3,10 @@ import { sha256Hex } from "src/common/__mocks__/HashMock";
 import { DEFAULT_LEGAL_OFFICER_ACCOUNT, setCurrentAddress } from "src/logion-chain/__mocks__/LogionChainMock";
 import { clickByName, typeByLabel, uploadByTestId } from "src/tests";
 import { TEST_WALLET_USER } from "src/wallet-user/TestData";
+import { EditableRequest } from "src/__mocks__/LogionClientMock";
 import { LocPrivateFileButton } from "./LocPrivateFileButton";
 import { LocItem } from "./types";
+import { setLocItems, setLocState } from "./__mocks__/LocContextMock";
 
 jest.mock("../common/hash");
 jest.mock("./LocContext");
@@ -30,29 +32,29 @@ describe("LocPrivateFileButton", () => {
     });
 
     it("uploads file", async () => {
-        const addFile = jest.fn();
-        await testUploadsFile(<LocPrivateFileButton
-            addFile={ addFile }
-            locItems={ [] }
-        />, addFile);
+        const { addFile } = mockEditableRequest();
+        await testUploadsFile(<LocPrivateFileButton/>, addFile);
     });
 
     it("does nothing on cancel", async () => {
-        const addFile = jest.fn();
-        await testDoesNothingOnCancel(<LocPrivateFileButton
-            addFile={ addFile }
-            locItems={ [] }
-        />, addFile);
+        const { addFile } = mockEditableRequest();
+        await testDoesNothingOnCancel(<LocPrivateFileButton/>, addFile);
     });
 
     it("does not upload file if already exists", async () => {
-        const addFile = jest.fn();
-        await testDoesNotNothingIfFileExists(<LocPrivateFileButton
-            addFile={ addFile }
-            locItems={ [ existingFileItem ] }
-        />, addFile);
+        const { addFile } = mockEditableRequest();
+        setLocItems([ existingFileItem ]);
+        await testDoesNotNothingIfFileExists(<LocPrivateFileButton/>, addFile);
     });
 });
+
+function mockEditableRequest(): { locState: EditableRequest, addFile: jest.Mock } {
+    const addFile = jest.fn();
+    const locState = new EditableRequest();
+    locState.addFile = addFile;
+    setLocState(locState);
+    return { addFile, locState };
+}
 
 async function testUploadsFile(component: React.ReactElement, addFile: jest.Mock) {
     sha256Hex.mockReturnValue(fileHash);

--- a/src/loc/LocPublicDataButton.test.tsx
+++ b/src/loc/LocPublicDataButton.test.tsx
@@ -1,9 +1,11 @@
 import { render, waitFor, screen } from "@testing-library/react";
+import { EditableRequest } from "src/__mocks__/LogionClientMock";
 import { DEFAULT_LEGAL_OFFICER_ACCOUNT, setCurrentAddress } from "../logion-chain/__mocks__/LogionChainMock";
 import { clickByName, typeByLabel } from "../tests";
 import { TEST_WALLET_USER } from "../wallet-user/TestData";
 import { LocPublicDataButton } from "./LocPublicDataButton";
 import { LocItem } from "./types";
+import { setLocItems, setLocState } from "./__mocks__/LocContextMock";
 
 jest.mock("./LocContext");
 jest.mock("./UserLocContext");
@@ -26,29 +28,29 @@ describe("LocPublicDataButton", () => {
     });
 
     it("adds metadata", async () => {
-        const addMetadata = jest.fn();
-        await testAddsMetadata(<LocPublicDataButton
-            addMetadata={ addMetadata }
-            locItems={ [] }
-        />, addMetadata);
+        const { addMetadata } = mockEditableRequest();
+        await testAddsMetadata(<LocPublicDataButton/>, addMetadata);
     });
 
     it("does nothing on cancel", async () => {
-        const addMetadata = jest.fn();
-        await testDoesNothingOnCancel(<LocPublicDataButton
-            addMetadata={ addMetadata }
-            locItems={ [] }
-        />, addMetadata);
+        const { addMetadata } = mockEditableRequest();
+        await testDoesNothingOnCancel(<LocPublicDataButton/>, addMetadata);
     });
 
     it("does not add metadata if already exists", async () => {
-        const addMetadata = jest.fn();
-        await testDoesNotNothingIfItemExists(<LocPublicDataButton
-            addMetadata={ addMetadata }
-            locItems={ [ existingItem ] }
-        />, addMetadata);
+        const { addMetadata } = mockEditableRequest();
+        setLocItems([ existingItem ]);
+        await testDoesNotNothingIfItemExists(<LocPublicDataButton/>, addMetadata);
     });
 });
+
+function mockEditableRequest(): { locState: EditableRequest, addMetadata: jest.Mock } {
+    const addMetadata = jest.fn();
+    const locState = new EditableRequest();
+    locState.addMetadata = addMetadata;
+    setLocState(locState);
+    return { addMetadata, locState };
+}
 
 async function testAddsMetadata(component: React.ReactElement, addMetadata: jest.Mock) {
     render(component);

--- a/src/loc/Model.test.tsx
+++ b/src/loc/Model.test.tsx
@@ -2,7 +2,7 @@ import { UUID } from "@logion/node-api";
 import { AxiosInstance } from "axios";
 
 import { DEFAULT_LEGAL_OFFICER } from "src/common/TestData";
-import { acceptLocRequest, acceptProtectionRequest, addLink, rejectLocRequest, rejectProtectionRequest } from "./Model"
+import { acceptLocRequest, acceptProtectionRequest, rejectLocRequest, rejectProtectionRequest } from "./Model"
 
 describe("Model", () => {
 
@@ -79,29 +79,6 @@ describe("Model", () => {
         expect(axios.post).toBeCalledWith(
             `/api/loc-request/${requestId}/accept`,
             expect.objectContaining({ })
-        )
-    })
-
-    it("adds link to LOC", async () => {
-        const axios = {
-            post: jest.fn().mockResolvedValue(undefined),
-        } as unknown as AxiosInstance;
-
-        const locId = "0e16421a-2550-4be5-a6a8-1ab2239b7dc4";
-        const nature = "Some link";
-        const target = "8f12876b-7fde-49b0-93a4-d29ed5179151";
-        await addLink(axios, {
-            locId,
-            nature,
-            target,
-        });
-
-        expect(axios.post).toBeCalledWith(
-            `/api/loc-request/${locId}/links`,
-            expect.objectContaining({
-                nature,
-                target,
-            })
         )
     })
 })

--- a/src/loc/Model.tsx
+++ b/src/loc/Model.tsx
@@ -56,18 +56,4 @@ export async function acceptLocRequest(
     await axios.post(`/api/loc-request/${parameters.requestId}/accept`, { });
 }
 
-export interface AddLinkParameters {
-    locId: string,
-    target: string,
-    nature: string
-}
-
-export async function addLink(
-    axios: AxiosInstance,
-    parameters: AddLinkParameters
-): Promise<void> {
-    const { target, nature } = parameters;
-    await axios.post(`/api/loc-request/${ parameters.locId }/links`, { target, nature })
-}
-
 export { getFile } from "./FileModel"

--- a/src/loc/UserContextualizedLocDetails.tsx
+++ b/src/loc/UserContextualizedLocDetails.tsx
@@ -20,7 +20,6 @@ export default function UserContextualizedLocDetails() {
         supersededLoc,
         locItems,
         deleteMetadata,
-        deleteFile,
         checkHash,
         checkResult,
         collectionItem,
@@ -44,7 +43,6 @@ export default function UserContextualizedLocDetails() {
                 locState={ locState }
                 locItems={ locItems }
                 checkResult={ checkResult }
-                deleteFile={ deleteFile }
                 deleteLink={ null }
                 deleteMetadata={ deleteMetadata }
                 viewer="User"

--- a/src/loc/UserContextualizedLocDetails.tsx
+++ b/src/loc/UserContextualizedLocDetails.tsx
@@ -21,7 +21,6 @@ export default function UserContextualizedLocDetails() {
         locItems,
         deleteMetadata,
         deleteFile,
-        addFile,
         checkHash,
         checkResult,
         collectionItem,
@@ -44,7 +43,6 @@ export default function UserContextualizedLocDetails() {
                 loc={ loc }
                 locState={ locState }
                 locItems={ locItems }
-                addFile={ addFile }
                 checkResult={ checkResult }
                 deleteFile={ deleteFile }
                 deleteLink={ null }

--- a/src/loc/UserContextualizedLocDetails.tsx
+++ b/src/loc/UserContextualizedLocDetails.tsx
@@ -21,7 +21,6 @@ export default function UserContextualizedLocDetails() {
         locItems,
         deleteMetadata,
         deleteFile,
-        addMetadata,
         addFile,
         checkHash,
         checkResult,
@@ -46,7 +45,6 @@ export default function UserContextualizedLocDetails() {
                 locState={ locState }
                 locItems={ locItems }
                 addFile={ addFile }
-                addMetadata={ addMetadata }
                 checkResult={ checkResult }
                 deleteFile={ deleteFile }
                 deleteLink={ null }

--- a/src/loc/__mocks__/LocContextMock.tsx
+++ b/src/loc/__mocks__/LocContextMock.tsx
@@ -85,6 +85,10 @@ export function setCollectionItems(items: CollectionItem[]) {
     collectionItems = items;
 }
 
+async function mutateLocState(mutator: (state: any) => Promise<any>): Promise<void> {
+    await mutator(locState);
+}
+
 export function useLocContext() {
     return {
         linkLoc: {
@@ -108,5 +112,6 @@ export function useLocContext() {
         voidLoc,
         voidLocExtrinsic: () => mockSignAndSubmit(() => {}),
         collectionItems,
+        mutateLocState,
     };
 }

--- a/src/loc/__snapshots__/ContextualizedLocDetails.test.tsx.snap
+++ b/src/loc/__snapshots__/ContextualizedLocDetails.test.tsx.snap
@@ -85,7 +85,6 @@ exports[`ContextualizedLocDetails renders 1`] = `
     protectionRequest={null}
   />
   <LocDetailsTab
-    addFile={[MockFunction]}
     checkResult={
       Object {
         "result": "NONE",
@@ -377,7 +376,6 @@ exports[`ContextualizedLocDetails renders empty 1`] = `
     protectionRequest={null}
   />
   <LocDetailsTab
-    addFile={[MockFunction]}
     checkResult={
       Object {
         "result": "NONE",

--- a/src/loc/__snapshots__/ContextualizedLocDetails.test.tsx.snap
+++ b/src/loc/__snapshots__/ContextualizedLocDetails.test.tsx.snap
@@ -90,7 +90,6 @@ exports[`ContextualizedLocDetails renders 1`] = `
         "result": "NONE",
       }
     }
-    deleteFile={[MockFunction]}
     deleteLink={[MockFunction]}
     deleteMetadata={[MockFunction]}
     loc={
@@ -381,7 +380,6 @@ exports[`ContextualizedLocDetails renders empty 1`] = `
         "result": "NONE",
       }
     }
-    deleteFile={[MockFunction]}
     deleteLink={[MockFunction]}
     deleteMetadata={[MockFunction]}
     loc={

--- a/src/loc/__snapshots__/ContextualizedLocDetails.test.tsx.snap
+++ b/src/loc/__snapshots__/ContextualizedLocDetails.test.tsx.snap
@@ -86,7 +86,6 @@ exports[`ContextualizedLocDetails renders 1`] = `
   />
   <LocDetailsTab
     addFile={[MockFunction]}
-    addMetadata={[MockFunction]}
     checkResult={
       Object {
         "result": "NONE",
@@ -379,7 +378,6 @@ exports[`ContextualizedLocDetails renders empty 1`] = `
   />
   <LocDetailsTab
     addFile={[MockFunction]}
-    addMetadata={[MockFunction]}
     checkResult={
       Object {
         "result": "NONE",

--- a/src/loc/__snapshots__/LocDetailsTab.test.tsx.snap
+++ b/src/loc/__snapshots__/LocDetailsTab.test.tsx.snap
@@ -314,61 +314,8 @@ exports[`LocDetailsTabContent renders closed data LOC for LO 1`] = `
     }
   />
   <LocItems
-    deleteFile={[Function]}
     deleteLink={[Function]}
     deleteMetadata={[Function]}
-    loc={
-      Object {
-        "closed": true,
-        "closedOn": "2022-09-28T08:49:00.000+02:00",
-        "createdOn": "2022-09-28T07:49:00.000+02:00",
-        "id": UUID {
-          "bytes": Uint8Array [
-            240,
-            175,
-            187,
-            187,
-            105,
-            109,
-            75,
-            119,
-            129,
-            112,
-            119,
-            229,
-            101,
-            136,
-            138,
-            14,
-          ],
-        },
-        "locType": "Transaction",
-        "status": "CLOSED",
-      }
-    }
-    locId={
-      UUID {
-        "bytes": Uint8Array [
-          240,
-          175,
-          187,
-          187,
-          105,
-          109,
-          75,
-          119,
-          129,
-          112,
-          119,
-          229,
-          101,
-          136,
-          138,
-          14,
-        ],
-      }
-    }
-    locItems={Array []}
     viewer="LegalOfficer"
   />
   <WarningDialog
@@ -554,61 +501,8 @@ exports[`LocDetailsTabContent renders closed data LOC for User 1`] = `
     }
   />
   <LocItems
-    deleteFile={[Function]}
     deleteLink={[Function]}
     deleteMetadata={[Function]}
-    loc={
-      Object {
-        "closed": true,
-        "closedOn": "2022-09-28T08:49:00.000+02:00",
-        "createdOn": "2022-09-28T07:49:00.000+02:00",
-        "id": UUID {
-          "bytes": Uint8Array [
-            240,
-            175,
-            187,
-            187,
-            105,
-            109,
-            75,
-            119,
-            129,
-            112,
-            119,
-            229,
-            101,
-            136,
-            138,
-            14,
-          ],
-        },
-        "locType": "Transaction",
-        "status": "CLOSED",
-      }
-    }
-    locId={
-      UUID {
-        "bytes": Uint8Array [
-          240,
-          175,
-          187,
-          187,
-          105,
-          109,
-          75,
-          119,
-          129,
-          112,
-          119,
-          229,
-          101,
-          136,
-          138,
-          14,
-        ],
-      }
-    }
-    locItems={Array []}
     viewer="User"
   />
   <WarningDialog
@@ -786,61 +680,8 @@ exports[`LocDetailsTabContent renders open data LOC for LO 1`] = `
     }
   />
   <LocItems
-    deleteFile={[Function]}
     deleteLink={[Function]}
     deleteMetadata={[Function]}
-    loc={
-      Object {
-        "closed": false,
-        "closedOn": undefined,
-        "createdOn": "2022-09-28T07:49:00.000+02:00",
-        "id": UUID {
-          "bytes": Uint8Array [
-            240,
-            175,
-            187,
-            187,
-            105,
-            109,
-            75,
-            119,
-            129,
-            112,
-            119,
-            229,
-            101,
-            136,
-            138,
-            14,
-          ],
-        },
-        "locType": "Transaction",
-        "status": "OPEN",
-      }
-    }
-    locId={
-      UUID {
-        "bytes": Uint8Array [
-          240,
-          175,
-          187,
-          187,
-          105,
-          109,
-          75,
-          119,
-          129,
-          112,
-          119,
-          229,
-          101,
-          136,
-          138,
-          14,
-        ],
-      }
-    }
-    locItems={Array []}
     viewer="LegalOfficer"
   />
   <Row>
@@ -1079,61 +920,8 @@ exports[`LocDetailsTabContent renders open data LOC for User 1`] = `
     }
   />
   <LocItems
-    deleteFile={[Function]}
     deleteLink={[Function]}
     deleteMetadata={[Function]}
-    loc={
-      Object {
-        "closed": false,
-        "closedOn": undefined,
-        "createdOn": "2022-09-28T07:49:00.000+02:00",
-        "id": UUID {
-          "bytes": Uint8Array [
-            240,
-            175,
-            187,
-            187,
-            105,
-            109,
-            75,
-            119,
-            129,
-            112,
-            119,
-            229,
-            101,
-            136,
-            138,
-            14,
-          ],
-        },
-        "locType": "Transaction",
-        "status": "OPEN",
-      }
-    }
-    locId={
-      UUID {
-        "bytes": Uint8Array [
-          240,
-          175,
-          187,
-          187,
-          105,
-          109,
-          75,
-          119,
-          129,
-          112,
-          119,
-          229,
-          101,
-          136,
-          138,
-          14,
-        ],
-      }
-    }
-    locItems={Array []}
     viewer="User"
   />
   <Row>
@@ -1371,61 +1159,8 @@ exports[`LocDetailsTabContent renders open identity LOC for LO 1`] = `
     />
   </React.Fragment>
   <LocItems
-    deleteFile={[Function]}
     deleteLink={[Function]}
     deleteMetadata={[Function]}
-    loc={
-      Object {
-        "closed": false,
-        "closedOn": undefined,
-        "createdOn": "2022-09-28T07:49:00.000+02:00",
-        "id": UUID {
-          "bytes": Uint8Array [
-            240,
-            175,
-            187,
-            187,
-            105,
-            109,
-            75,
-            119,
-            129,
-            112,
-            119,
-            229,
-            101,
-            136,
-            138,
-            14,
-          ],
-        },
-        "locType": "Identity",
-        "status": "OPEN",
-      }
-    }
-    locId={
-      UUID {
-        "bytes": Uint8Array [
-          240,
-          175,
-          187,
-          187,
-          105,
-          109,
-          75,
-          119,
-          129,
-          112,
-          119,
-          229,
-          101,
-          136,
-          138,
-          14,
-        ],
-      }
-    }
-    locItems={Array []}
     viewer="LegalOfficer"
   />
   <Row>
@@ -1665,62 +1400,8 @@ exports[`LocDetailsTabContent renders void data LOC for LO 1`] = `
     }
   />
   <LocItems
-    deleteFile={[Function]}
     deleteLink={[Function]}
     deleteMetadata={[Function]}
-    loc={
-      Object {
-        "closed": false,
-        "closedOn": undefined,
-        "createdOn": "2022-09-28T07:49:00.000+02:00",
-        "id": UUID {
-          "bytes": Uint8Array [
-            240,
-            175,
-            187,
-            187,
-            105,
-            109,
-            75,
-            119,
-            129,
-            112,
-            119,
-            229,
-            101,
-            136,
-            138,
-            14,
-          ],
-        },
-        "locType": "Transaction",
-        "status": "OPEN",
-        "voidInfo": Object {},
-      }
-    }
-    locId={
-      UUID {
-        "bytes": Uint8Array [
-          240,
-          175,
-          187,
-          187,
-          105,
-          109,
-          75,
-          119,
-          129,
-          112,
-          119,
-          229,
-          101,
-          136,
-          138,
-          14,
-        ],
-      }
-    }
-    locItems={Array []}
     viewer="LegalOfficer"
   />
   <WarningDialog
@@ -1899,62 +1580,8 @@ exports[`LocDetailsTabContent renders void data LOC for User 1`] = `
     }
   />
   <LocItems
-    deleteFile={[Function]}
     deleteLink={[Function]}
     deleteMetadata={[Function]}
-    loc={
-      Object {
-        "closed": false,
-        "closedOn": undefined,
-        "createdOn": "2022-09-28T07:49:00.000+02:00",
-        "id": UUID {
-          "bytes": Uint8Array [
-            240,
-            175,
-            187,
-            187,
-            105,
-            109,
-            75,
-            119,
-            129,
-            112,
-            119,
-            229,
-            101,
-            136,
-            138,
-            14,
-          ],
-        },
-        "locType": "Transaction",
-        "status": "OPEN",
-        "voidInfo": Object {},
-      }
-    }
-    locId={
-      UUID {
-        "bytes": Uint8Array [
-          240,
-          175,
-          187,
-          187,
-          105,
-          109,
-          75,
-          119,
-          129,
-          112,
-          119,
-          229,
-          101,
-          136,
-          138,
-          14,
-        ],
-      }
-    }
-    locItems={Array []}
     viewer="User"
   />
   <WarningDialog

--- a/src/loc/__snapshots__/LocDetailsTab.test.tsx.snap
+++ b/src/loc/__snapshots__/LocDetailsTab.test.tsx.snap
@@ -852,10 +852,7 @@ exports[`LocDetailsTabContent renders open data LOC for LO 1`] = `
         align="left"
       >
         <LocPublicDataButton />
-        <LocPrivateFileButton
-          addFile={[Function]}
-          locItems={Array []}
-        />
+        <LocPrivateFileButton />
       </ButtonGroup>
     </Col>
     <React.Fragment>
@@ -1148,10 +1145,7 @@ exports[`LocDetailsTabContent renders open data LOC for User 1`] = `
         align="left"
       >
         <LocPublicDataButton />
-        <LocPrivateFileButton
-          addFile={[Function]}
-          locItems={Array []}
-        />
+        <LocPrivateFileButton />
       </ButtonGroup>
     </Col>
     <React.Fragment>
@@ -1443,10 +1437,7 @@ exports[`LocDetailsTabContent renders open identity LOC for LO 1`] = `
         align="left"
       >
         <LocPublicDataButton />
-        <LocPrivateFileButton
-          addFile={[Function]}
-          locItems={Array []}
-        />
+        <LocPrivateFileButton />
       </ButtonGroup>
     </Col>
     <React.Fragment>

--- a/src/loc/__snapshots__/LocDetailsTab.test.tsx.snap
+++ b/src/loc/__snapshots__/LocDetailsTab.test.tsx.snap
@@ -851,10 +851,7 @@ exports[`LocDetailsTabContent renders open data LOC for LO 1`] = `
       <ButtonGroup
         align="left"
       >
-        <LocPublicDataButton
-          addMetadata={[Function]}
-          locItems={Array []}
-        />
+        <LocPublicDataButton />
         <LocPrivateFileButton
           addFile={[Function]}
           locItems={Array []}
@@ -1150,10 +1147,7 @@ exports[`LocDetailsTabContent renders open data LOC for User 1`] = `
       <ButtonGroup
         align="left"
       >
-        <LocPublicDataButton
-          addMetadata={[Function]}
-          locItems={Array []}
-        />
+        <LocPublicDataButton />
         <LocPrivateFileButton
           addFile={[Function]}
           locItems={Array []}
@@ -1448,10 +1442,7 @@ exports[`LocDetailsTabContent renders open identity LOC for LO 1`] = `
       <ButtonGroup
         align="left"
       >
-        <LocPublicDataButton
-          addMetadata={[Function]}
-          locItems={Array []}
-        />
+        <LocPublicDataButton />
         <LocPrivateFileButton
           addFile={[Function]}
           locItems={Array []}

--- a/src/loc/__snapshots__/UserContextualizedLocDetails.test.tsx.snap
+++ b/src/loc/__snapshots__/UserContextualizedLocDetails.test.tsx.snap
@@ -40,7 +40,6 @@ exports[`UserContextualizedLocDetails renders 1`] = `
   }
 >
   <LocDetailsTab
-    addFile={[MockFunction]}
     checkResult={
       Object {
         "result": "NONE",

--- a/src/loc/__snapshots__/UserContextualizedLocDetails.test.tsx.snap
+++ b/src/loc/__snapshots__/UserContextualizedLocDetails.test.tsx.snap
@@ -45,7 +45,6 @@ exports[`UserContextualizedLocDetails renders 1`] = `
         "result": "NONE",
       }
     }
-    deleteFile={[MockFunction]}
     deleteLink={null}
     deleteMetadata={[MockFunction]}
     legalOfficer={

--- a/src/loc/__snapshots__/UserContextualizedLocDetails.test.tsx.snap
+++ b/src/loc/__snapshots__/UserContextualizedLocDetails.test.tsx.snap
@@ -41,7 +41,6 @@ exports[`UserContextualizedLocDetails renders 1`] = `
 >
   <LocDetailsTab
     addFile={[MockFunction]}
-    addMetadata={[MockFunction]}
     checkResult={
       Object {
         "result": "NONE",

--- a/src/wallet-user/UserContext.tsx
+++ b/src/wallet-user/UserContext.tsx
@@ -493,10 +493,12 @@ export function UserContextProvider(props: Props) {
 
     const mutateLocsStateCallback = useCallback(async (mutator: (current: LocsState) => Promise<LocsState>): Promise<void> => {
         const newState = await mutator(contextValue.locsState!);
-        dispatch({
-            type: "MUTATE_LOCS_STATE",
-            locsState: newState,
-        });
+        if(newState !== contextValue.locsState) {
+            dispatch({
+                type: "MUTATE_LOCS_STATE",
+                locsState: newState,
+            });
+        }
     }, [ contextValue.locsState ]);
 
     useEffect(() => {


### PR DESCRIPTION
* Removed `addMetadata`, `addFile`, `addLink` and `deleteFile` functions from context
* Replaced by `mutateLocState` and a call to the state's method in the mutator
* Other methods will be handled later