### PR TITLE
Refactor item publish/confirm

### DIFF
--- a/src/ClientExtrinsicSubmitter.tsx
+++ b/src/ClientExtrinsicSubmitter.tsx
@@ -39,6 +39,7 @@ export default function ClientExtrinsicSubmitter(props: Props) {
                     await props.call!((callbackResult: ISubmittableResult) => setResult(callbackResult));
                     setCallEnded(true);
                 } catch(e) {
+                    console.log(e);
                     setError(e);
                 }
             })();

--- a/src/common/Model.tsx
+++ b/src/common/Model.tsx
@@ -39,25 +39,6 @@ export async function createLocRequest(
     return response.data;
 }
 
-export async function confirmLocFile(
-    axios: AxiosInstance,
-    locId: UUID,
-    hash: string
-): Promise<void> {
-    const requestId = locId.toString();
-    await axios.put(`/api/loc-request/${requestId}/files/${hash}/confirm`);
-}
-
-export async function confirmLocLink(
-    axios: AxiosInstance,
-    locId: UUID,
-    targetId: UUID
-): Promise<void> {
-    const requestId = locId.toString();
-    const target = targetId.toString();
-    await axios.put(`/api/loc-request/${requestId}/links/${target}/confirm`);
-}
-
 export async function deleteLocLink(
     axios: AxiosInstance,
     locId: UUID,
@@ -66,15 +47,6 @@ export async function deleteLocLink(
     const requestId = locId.toString();
     const target = targetId.toString();
     await axios.delete(`/api/loc-request/${requestId}/links/${target}`);
-}
-
-export async function confirmLocMetadataItem(
-    axios: AxiosInstance,
-    locId: UUID,
-    name: string
-): Promise<void> {
-    const requestId = locId.toString();
-    await axios.put(`/api/loc-request/${requestId}/metadata/${(encodeURIComponent(name))}/confirm`);
 }
 
 export async function preClose(

--- a/src/common/__mocks__/Model.tsx
+++ b/src/common/__mocks__/Model.tsx
@@ -1,9 +1,6 @@
 import {
     fetchProtectionRequests,
     createLocRequest,
-    confirmLocFile,
-    confirmLocLink,
-    confirmLocMetadataItem,
     deleteLocLink,
     preClose,
     preVoid,
@@ -13,9 +10,6 @@ import {
 export {
     fetchProtectionRequests,
     createLocRequest,
-    confirmLocFile,
-    confirmLocLink,
-    confirmLocMetadataItem,
     deleteLocLink,
     preClose,
     preVoid,

--- a/src/common/__mocks__/ModelMock.ts
+++ b/src/common/__mocks__/ModelMock.ts
@@ -20,17 +20,11 @@ export async function createLocRequest(axios: any, request: CreateLocRequest): P
     });
 }
 
-export const confirmLocFile = jest.fn();
-export const confirmLocLink = jest.fn();
-export const confirmLocMetadataItem = jest.fn();
 export const deleteLocLink = jest.fn();
 export const preVoid = jest.fn();
 export const preClose = jest.fn();
 
 export function resetDefaultMocks() {
-    confirmLocFile.mockResolvedValue(undefined);
-    confirmLocLink.mockResolvedValue(undefined);
-    confirmLocMetadataItem.mockResolvedValue(undefined);
     deleteLocLink.mockResolvedValue(undefined);
     preVoid.mockResolvedValue(undefined);
     preClose.mockResolvedValue(undefined);

--- a/src/legal-officer/client.test.ts
+++ b/src/legal-officer/client.test.ts
@@ -21,12 +21,14 @@ describe("Legal Officer client", () => {
                 id: locId,
             }),
             refresh: () => Promise.resolve(locState),
+            locsState: () => ({
+                client,
+            }),
         } as EditableRequest;
 
         const nature = "Some link";
         const target = new UUID("8f12876b-7fde-49b0-93a4-d29ed5179151");
         await addLink({
-            client,
             locState,
             target,
             nature,

--- a/src/legal-officer/client.ts
+++ b/src/legal-officer/client.ts
@@ -1,14 +1,108 @@
-import { LogionClient, EditableRequest } from "@logion/client";
-import { UUID } from "@logion/node-api";
+import { EditableRequest, Signer, SignCallback, LocRequestState } from "@logion/client";
+import { UUID, addLink as nodeApiAddLink, addFile as nodeApiAddFile, addMetadata as nodeApiAddMetadata, MetadataItem } from "@logion/node-api";
 
 export async function addLink(params: {
-    client: LogionClient,
     locState: EditableRequest,
     target: UUID,
     nature: string,
 }): Promise<EditableRequest> {
-    const { client, locState, target, nature } = params;
-    const axios = client.buildAxios(client.legalOfficers.find(legalOfficer => locState.data().ownerAddress === legalOfficer.address)!);
+    const { locState, target, nature } = params;
+    const axios = buildAxios(locState);
     await axios.post(`/api/loc-request/${ locState.data().id.toString() }/links`, { target: target.toString(), nature })
+    return await locState.refresh() as EditableRequest;
+}
+
+function buildAxios(locState: LocRequestState) {
+    const client = locState.locsState().client;
+    return client.buildAxios(client.legalOfficers.find(legalOfficer => locState.data().ownerAddress === legalOfficer.address)!);
+}
+
+export async function publishLink(params: {
+    locState: EditableRequest,
+    target: UUID,
+    nature: string,
+    signer: Signer,
+    callback: SignCallback,
+}): Promise<EditableRequest> {
+    const { locState, target, nature, signer, callback } = params;
+
+    const client = locState.locsState().client;
+    const api = client.nodeApi;
+    const locId = locState.data().id;
+    const submittable = nodeApiAddLink({
+        locId,
+        api,
+        target,
+        nature,
+    });
+    await signer.signAndSend({
+        signerId: locState.data().ownerAddress,
+        submittable,
+        callback
+    });
+
+    const axios = buildAxios(locState);
+    await axios.put(`/api/loc-request/${ locId.toString() }/links/${ target.toString() }/confirm`);
+
+    return await locState.refresh() as EditableRequest;
+}
+
+export async function publishFile(params: {
+    locState: EditableRequest,
+    hash: string,
+    nature: string,
+    submitter: string,
+    signer: Signer,
+    callback: SignCallback,
+}): Promise<EditableRequest> {
+    const { locState, hash, nature, submitter, signer, callback } = params;
+
+    const client = locState.locsState().client;
+    const api = client.nodeApi;
+    const locId = locState.data().id;
+    const submittable = nodeApiAddFile({
+        locId,
+        api,
+        hash,
+        nature,
+        submitter,
+    });
+    await signer.signAndSend({
+        signerId: locState.data().ownerAddress,
+        submittable,
+        callback
+    });
+
+    const axios = buildAxios(locState);
+    await axios.put(`/api/loc-request/${ locId.toString() }/files/${ hash }/confirm`);
+
+    return await locState.refresh() as EditableRequest;
+}
+
+export async function publishMetadata(params: {
+    locState: EditableRequest,
+    item: MetadataItem,
+    signer: Signer,
+    callback: SignCallback,
+}): Promise<EditableRequest> {
+    const { locState, item, signer, callback } = params;
+
+    const client = locState.locsState().client;
+    const api = client.nodeApi;
+    const locId = locState.data().id;
+    const submittable = nodeApiAddMetadata({
+        locId,
+        api,
+        item,
+    });
+    await signer.signAndSend({
+        signerId: locState.data().ownerAddress,
+        submittable,
+        callback
+    });
+
+    const axios = buildAxios(locState);
+    await axios.put(`/api/loc-request/${ locId.toString() }/metadata/${ encodeURIComponent(item.name) }/confirm`);
+
     return await locState.refresh() as EditableRequest;
 }

--- a/src/loc/LocLinkButton.tsx
+++ b/src/loc/LocLinkButton.tsx
@@ -30,7 +30,6 @@ export default function LocLinkButton(props: Props) {
         await mutateLocState(async current => {
             if(client && current instanceof EditableRequest) {
                 return await addLink({
-                    client,
                     locState: current,
                     target,
                     nature,

--- a/src/loc/LocLinkExistingLocDialog.tsx
+++ b/src/loc/LocLinkExistingLocDialog.tsx
@@ -45,7 +45,6 @@ export default function LocLinkExistingDialog(props: Props) {
             if(client && current instanceof EditableRequest) {
                 const locData = current.locsState().findById(locId).data();
                 return await addLink({
-                    client,
                     locState: current,
                     target: locData.id,
                     nature: formValues.linkNature,

--- a/src/loc/LocPublishButton.test.tsx
+++ b/src/loc/LocPublishButton.test.tsx
@@ -1,13 +1,12 @@
 import { render, waitFor, screen } from "@testing-library/react";
 import { mockSubmittableResult } from "src/logion-chain/__mocks__/SignatureMock";
 
-import { SignAndSubmit } from "../ExtrinsicSubmitter";
-import { SignedTransaction } from "../logion-chain/Signature";
 import { clickByName } from "../tests";
-import { setIsSuccessful } from "../__mocks__/LogionClientMock";
 import LocPublishButton from "./LocPublishButton";
 
 import { LocItem } from "./types";
+
+jest.mock("./LocContext");
 
 describe("LocPublishButton", () => {
 
@@ -24,14 +23,14 @@ describe("LocPublishButton", () => {
             newItem: false,
         };
         const confirm = jest.fn();
-        let setResultCallback: React.Dispatch<React.SetStateAction<SignedTransaction | null>>;
-        const signAndSubmit: SignAndSubmit = setResult => { setResultCallback = setResult };
-        const signAndSubmitFactory: ((item: LocItem) => SignAndSubmit) | null = () => signAndSubmit;
         render(<LocPublishButton
             itemType="Public Data"
             locItem={ locItem }
-            confirm={ confirm }
-            signAndSubmitFactory={ signAndSubmitFactory }
+            publishMutator={ async (current, callback) => {
+                callback(mockSubmittableResult(true));
+                confirm();
+                return current;
+            }}
         />);
 
         // When publishing
@@ -41,7 +40,6 @@ describe("LocPublishButton", () => {
         await clickByName("Publish");
 
         // Then item published
-        setResultCallback!(mockSubmittableResult(true));
         await waitFor(() => screen.getByText(/successful/i));
         expect(confirm).toBeCalled();
 

--- a/src/loc/LocPublishLinkButton.tsx
+++ b/src/loc/LocPublishLinkButton.tsx
@@ -1,19 +1,33 @@
-import { useLocContext } from "./LocContext";
+import { EditableRequest } from "@logion/client";
+
 import { LocItem } from "./types";
 import LocPublishButton from "./LocPublishButton";
+import { publishLink } from "src/legal-officer/client";
+import { useLogionChain } from "src/logion-chain";
 
 export interface Props {
     locItem: LocItem;
 }
 
 export default function LocPublishLinkButton(props: Props) {
-    const { publishLink, confirmLink } = useLocContext();
+    const { signer } = useLogionChain();
 
     return (
         <LocPublishButton
             locItem={ props.locItem }
-            confirm={ confirmLink }
-            signAndSubmitFactory={ publishLink }
+            publishMutator={ async (current, callback) => {
+                if(current instanceof EditableRequest) {
+                    return await publishLink({
+                        locState: current,
+                        target: props.locItem.target!,
+                        nature: props.locItem.nature!,
+                        signer: signer!,
+                        callback,
+                    });
+                } else {
+                    return current;
+                }
+            }}
             itemType="Link"
         />
     )

--- a/src/loc/LocPublishPrivateFileButton.tsx
+++ b/src/loc/LocPublishPrivateFileButton.tsx
@@ -1,19 +1,34 @@
-import { useLocContext } from "./LocContext";
+import { EditableRequest } from "@logion/client";
+
 import { LocItem } from "./types";
 import LocPublishButton from "./LocPublishButton";
+import { publishFile } from "src/legal-officer/client";
+import { useLogionChain } from "src/logion-chain";
 
 export interface Props {
     locItem: LocItem;
 }
 
 export default function LocPublishPrivateFileButton(props: Props) {
-    const { publishFile, confirmFile } = useLocContext();
+    const { signer } = useLogionChain();
 
     return (
         <LocPublishButton
             locItem={ props.locItem }
-            confirm={ confirmFile }
-            signAndSubmitFactory={ publishFile }
+            publishMutator={ async (current, callback) => {
+                if(current instanceof EditableRequest) {
+                    return await publishFile({
+                        locState: current,
+                        hash: props.locItem.value,
+                        nature: props.locItem.nature!,
+                        submitter: props.locItem.submitter,
+                        signer: signer!,
+                        callback,
+                    });
+                } else {
+                    return current;
+                }
+            }}
             itemType="Document"
         />
     )

--- a/src/loc/LocPublishPublicDataButton.tsx
+++ b/src/loc/LocPublishPublicDataButton.tsx
@@ -1,19 +1,36 @@
-import { useLocContext } from "./LocContext";
+import { EditableRequest } from "@logion/client";
+
 import { LocItem } from "./types";
 import LocPublishButton from "./LocPublishButton";
+import { publishMetadata } from "src/legal-officer/client";
+import { useLogionChain } from "src/logion-chain";
 
 export interface Props {
     locItem: LocItem;
 }
 
 export default function LocPublishPublicDataButton(props: Props) {
-    const { publishMetadata, confirmMetadata } = useLocContext();
+    const { signer } = useLogionChain();
 
     return (
         <LocPublishButton
             locItem={ props.locItem }
-            confirm={ confirmMetadata }
-            signAndSubmitFactory={ publishMetadata }
+            publishMutator={ async (current, callback) => {
+                if(current instanceof EditableRequest) {
+                    return await publishMetadata({
+                        locState: current,
+                        item: {
+                            name: props.locItem.name,
+                            value: props.locItem.value,
+                            submitter: props.locItem.submitter,
+                        },
+                        signer: signer!,
+                        callback,
+                    });
+                } else {
+                    return current;
+                }
+            }}
             itemType="Public Data"
         />
     )

--- a/src/loc/__snapshots__/LocPublishLinkButton.test.tsx.snap
+++ b/src/loc/__snapshots__/LocPublishLinkButton.test.tsx.snap
@@ -35,5 +35,6 @@ exports[`LocPublishLinkButton renders 1`] = `
       "value": "link-value",
     }
   }
+  publishMutator={[Function]}
 />
 `;

--- a/src/loc/__snapshots__/LocPublishPrivateFileButton.test.tsx.snap
+++ b/src/loc/__snapshots__/LocPublishPrivateFileButton.test.tsx.snap
@@ -15,5 +15,6 @@ exports[`LocPublishPrivateFileButton renders 1`] = `
       "value": "file-value",
     }
   }
+  publishMutator={[Function]}
 />
 `;

--- a/src/loc/__snapshots__/LocPublishPublicDataButton.test.tsx.snap
+++ b/src/loc/__snapshots__/LocPublishPublicDataButton.test.tsx.snap
@@ -15,5 +15,6 @@ exports[`LocPublishPublicDataButton renders 1`] = `
       "value": "data-value",
     }
   }
+  publishMutator={[Function]}
 />
 `;

--- a/src/loc/types.ts
+++ b/src/loc/types.ts
@@ -1,7 +1,8 @@
+import { LocRequestState } from "@logion/client";
 import { UUID } from "@logion/node-api/dist/UUID"
+import { CallCallback } from "src/ClientExtrinsicSubmitter";
 
 import { sha256HexFromString } from "../common/hash";
-import { SignAndSubmit } from "../ExtrinsicSubmitter"
 
 export type LocItemStatus = 'DRAFT' | 'PUBLISHED'
 
@@ -36,8 +37,7 @@ export interface PublishState {
 export interface PublishProps {
     locItem: LocItem;
     itemType: 'Public Data' | 'Document' | 'Link';
-    signAndSubmitFactory: ((item: LocItem) => SignAndSubmit) | null;
-    confirm: ((item: LocItem) => void) | null;
+    publishMutator: (current: LocRequestState, callback: CallCallback) => Promise<LocRequestState>;
 }
 
 export function toItemId(maybeHex: string): string | undefined {

--- a/src/logion-chain/__mocks__/LogionChainMock.ts
+++ b/src/logion-chain/__mocks__/LogionChainMock.ts
@@ -157,6 +157,12 @@ export function setContextMock(value: any) {
 
 let axiosFactory = () => axiosMock.object();
 
+let signAndSend = jest.fn().mockResolvedValue(undefined);
+
+let signer = {
+    signAndSend,
+};
+
 export function useLogionChain() {
     if(context) {
         return context;
@@ -177,6 +183,7 @@ export function useLogionChain() {
             client: clientMock,
             isCurrentAuthenticated: () => true,
             authenticateAddress,
+            signer,
         };
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2938,14 +2938,14 @@ __metadata:
   linkType: hard
 
 "@logion/client@npm:^0.15.0-1":
-  version: 0.15.0-10
-  resolution: "@logion/client@npm:0.15.0-10"
+  version: 0.15.0-11
+  resolution: "@logion/client@npm:0.15.0-11"
   dependencies:
     "@logion/node-api": ^0.7.0
     axios: ^0.27.2
     luxon: ^3.0.1
     mime-db: ^1.52.0
-  checksum: a4c104d68d5af0aeb142a2a8fb40d3bb467e49b607e3a6c88b20e371fabdf127e07bc1de0624259bef92fa4c9fcaec281792e398c2c6bf13c2b2d201d5194659
+  checksum: 9a4da36bd8fd026dc3f87cc63d4e97bd1ac4980b9981e741ef5c65e313725d1e0ccfee63d7995d2d5303de3cb7f7fbf7321ab8f2f802002120b3fc6895ebcc62
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
* Publication logic was rewritten in a way more similar to logion SDK
* `mutateLocState` is used for publication

logion-network/logion-internal#643