### PR TITLE
Fix state discarded issues with LOG operations

### DIFF
--- a/src/__mocks__/LogionClientMock.ts
+++ b/src/__mocks__/LogionClientMock.ts
@@ -81,7 +81,9 @@ export class AccountTokens {
 export class LocRequestState {
     data: any;
     locsState: any;
-    refresh: (() => Promise<LocRequestState>) | undefined;
+    async refresh(): Promise<LocRequestState> {
+        return this;
+    }
     getCurrentState() {
         return this;
     }
@@ -109,7 +111,6 @@ export class DraftRequest extends EditableRequest {
 export class OpenLoc extends EditableRequest {
     data: any;
     locsState: any;
-    refresh: (() => Promise<EditableRequest>) | undefined;
     addMetadata: jest.Mock<Promise<EditableRequest>> | undefined;
     deleteMetadata: jest.Mock<Promise<EditableRequest>> | undefined;
     addFile: jest.Mock<Promise<EditableRequest>> | undefined;

--- a/src/__mocks__/LogionClientMock.ts
+++ b/src/__mocks__/LogionClientMock.ts
@@ -82,6 +82,9 @@ export class LocRequestState {
     data: any;
     locsState: any;
     refresh: (() => Promise<LocRequestState>) | undefined;
+    getCurrentState() {
+        return this;
+    }
 }
 
 export class ClosedCollectionLoc extends LocRequestState {

--- a/src/legal-officer/client.test.ts
+++ b/src/legal-officer/client.test.ts
@@ -1,7 +1,7 @@
 import { EditableRequest, LogionClient, OpenLoc, VerifiedThirdParty, ClosedLoc, Signer, SuccessfulSubmission } from "@logion/client";
 import { UUID } from "@logion/node-api";
 import { AxiosInstance } from "axios";
-import { DEFAULT_ADDRESS, DEFAULT_LEGAL_OFFICER } from "src/common/TestData";
+import { DEFAULT_LEGAL_OFFICER } from "src/common/TestData";
 import { ApiPromise } from "src/__mocks__/PolkadotApiMock";
 import { addLink, getVerifiedThirdPartySelections, requestVote } from "./client";
 
@@ -26,6 +26,7 @@ describe("Legal Officer client", () => {
             locsState: () => ({
                 client,
             }),
+            getCurrentState: () => locState,
         } as unknown as EditableRequest;
 
         const nature = "Some link";
@@ -83,6 +84,7 @@ describe("Legal Officer client", () => {
             locsState: () => ({
                 client,
             }),
+            getCurrentState: () => locState,
         } as unknown as OpenLoc;
 
         const verifiedThirdParties: VerifiedThirdParty[] = await getVerifiedThirdPartySelections({ locState });
@@ -107,6 +109,8 @@ describe("Legal Officer client", () => {
 
         const client = {
             nodeApi,
+            legalOfficers: [],
+            buildAxios: () => {},
         } as unknown as LogionClient;
 
         const locId = new UUID("0e16421a-2550-4be5-a6a8-1ab2239b7dc4");
@@ -118,6 +122,7 @@ describe("Legal Officer client", () => {
             locsState: () => ({
                 client,
             }),
+            getCurrentState: () => locState,
         } as unknown as ClosedLoc;
 
         const result = {

--- a/src/loc/LocContext.test.tsx
+++ b/src/loc/LocContext.test.tsx
@@ -92,7 +92,8 @@ function givenRequest<T extends LocRequestState>(locId: string, loc: LegalOffice
         _linkedLocState = {
             data: () => _linkedLocData,
             locsState: () => locsState,
-        } as unknown as RealOpenLoc;
+            refresh: () => Promise.resolve(_linkedLocData),
+        } as unknown as OpenLoc;
     }
 
     locsState.findById = (argLocId: UUID) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2984,27 +2984,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@logion/client@npm:^0.20.0-1":
-  version: 0.20.0-5
-  resolution: "@logion/client@npm:0.20.0-5"
+"@logion/client@npm:^0.20.0-1, @logion/client@npm:^0.20.0-6":
+  version: 0.20.0-7
+  resolution: "@logion/client@npm:0.20.0-7"
   dependencies:
     "@logion/node-api": ^0.10.1-2
     axios: ^0.27.2
     luxon: ^3.0.1
     mime-db: ^1.52.0
-  checksum: f1929795b420c31ee6c5457a4b8036ea475f3a5466162e791b8859c3ca6671dfa06a4578a7bccdfd9423fd01d3f8e6c1e70ae84f7c399482fbedc40e6417d5a2
-  languageName: node
-  linkType: hard
-
-"@logion/client@npm:^0.20.0-6":
-  version: 0.20.0-6
-  resolution: "@logion/client@npm:0.20.0-6"
-  dependencies:
-    "@logion/node-api": ^0.10.1-2
-    axios: ^0.27.2
-    luxon: ^3.0.1
-    mime-db: ^1.52.0
-  checksum: 7bf9a25bfe225c8d6ff2ad4b34247c3a0cf5ee3f3d3283534e36fb02008ff14481bcee379a85e4fbd58690b4bea36679d5a8c5bb392d68a1ac6e3ee27f413975
+  checksum: 583c087fd407756489c18edd765641fda77320fea942a4f5b9c3d15595fa02fdfdea83852012eecce286f329d79eebdb687ade92d002e7abba04a9f17ca68a2b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
* Each time a LOC state is involved, enforce use of current state.
* Collect all LOC data before awaiting (on await, execution thread may switch and cause the state to be discarded).
* After interactions with chain or backend, enforce refresh from current state.

logion-network/logion-internal#693