### PR TITLE
Add tokens records to SOF.

### DIFF
--- a/src/loc/statement/SofFilesAndDeliveriesEN.tsx
+++ b/src/loc/statement/SofFilesAndDeliveriesEN.tsx
@@ -1,0 +1,39 @@
+import { SofDeliverableFile } from "./SofParams.js";
+
+export interface Props {
+    files: SofDeliverableFile[]
+}
+
+export default function SofFilesAndDeliveriesEN(props: Props) {
+    return (
+        <>
+            {
+                props.files.map((file, index) => (
+                    <>
+                        <div className="section-name"><strong>Underlying asset #{index + 1}</strong></div>
+                        <div>Name: { file.name }</div>
+                        <div>Content Type: { file.contentType }</div>
+                        <div className="large-value">Hash: { file.hash }</div>
+                        <div>Size: { file.size.toString() } bytes</div>
+                        {
+                            file.deliveries.length > 0 &&
+                            <div>Claimed copies:</div>
+                        }
+                        {
+                            file.deliveries.map((delivery, deliveryIndex) => (
+                                <>
+                                    <div className="large-value">
+                                        Delivery #{ deliveryIndex + 1 } Copy Hash: { delivery.hash }
+                                    </div>
+                                    <div className="large-value">
+                                        elivery #{ deliveryIndex + 1 } Owner: { delivery.owner }
+                                    </div>
+                                </>
+                            ))
+                        }
+                    </>
+                ))
+            }
+        </>
+    )
+}

--- a/src/loc/statement/SofFilesAndDeliveriesFR.tsx
+++ b/src/loc/statement/SofFilesAndDeliveriesFR.tsx
@@ -1,0 +1,39 @@
+import { SofDeliverableFile } from "./SofParams.js";
+
+export interface Props {
+    files: SofDeliverableFile[]
+}
+
+export default function SofFilesAndDeliveriesFR(props: Props) {
+    return (
+        <>
+            {
+                props.files.map((file, index) => (
+                    <>
+                        <div className="section-name"><strong>Contenu sous-jacent #{ index + 1 }</strong></div>
+                        <div>Nom: { file.name }</div>
+                        <div>Type de contenu: { file.contentType }</div>
+                        <div className="large-value">Hash: { file.hash }</div>
+                        <div>Taille: { file.size.toString() } octets</div>
+                        {
+                            file.deliveries.length > 0 &&
+                            <div>Copies réclamées:</div>
+                        }
+                        {
+                            file.deliveries.map((delivery, deliveryIndex) => (
+                                <>
+                                    <div className="large-value">
+                                        Copie #{ deliveryIndex + 1 } - hash de la copie: { delivery.hash }
+                                    </div>
+                                    <div className="large-value">
+                                        Copie #{ deliveryIndex + 1 } - détenteur: { delivery.owner }
+                                    </div>
+                                </>
+                            ))
+                        }
+                    </>
+                ))
+            }
+        </>
+    )
+}

--- a/src/loc/statement/SofParams.ts
+++ b/src/loc/statement/SofParams.ts
@@ -33,7 +33,7 @@ export interface SofFileDelivery {
     owner: string;
 }
 
-export interface SofCollectionItemFile {
+export interface SofDeliverableFile {
     name: string;
     contentType: string;
     size: string;
@@ -50,7 +50,7 @@ export interface SofCollectionItem {
     id: string;
     description: string;
     addedOn: string;
-    files: SofCollectionItemFile[];
+    files: SofDeliverableFile[];
     token?: ItemToken;
     restrictedDelivery: boolean;
     logionClassification?: SofLogionClassification;
@@ -85,6 +85,7 @@ interface LocInfo {
     publicItems: PublicItem[];
     privateItems: PrivateItem[];
     collectionItem?: SofCollectionItem;
+    tokensRecords: SofTokensRecord[];
 }
 
 interface SettingsData {
@@ -92,6 +93,14 @@ interface SettingsData {
     sealUrl: string;
     oathText: string;
     oathLogoUrl: string;
+}
+
+export interface SofTokensRecord {
+    id: string;
+    description: string;
+    addedOn: string;
+    files: SofDeliverableFile[];
+    issuer: string;
 }
 
 export interface SofParams extends Prerequisites, LocInfo, FormValues, SettingsData {
@@ -124,6 +133,7 @@ export const DEFAULT_SOF_PARAMS: SofParams = {
     oathText: "",
     oathLogoUrl: "",
     sealUrl: "",
+    tokensRecords: [],
 }
 
 export interface Prerequisite {

--- a/src/loc/statement/SofTokensRecordEN.tsx
+++ b/src/loc/statement/SofTokensRecordEN.tsx
@@ -1,0 +1,17 @@
+import { SofTokensRecord } from "./SofParams.js";
+import SofFilesAndDeliveriesEN from "./SofFilesAndDeliveriesEN";
+
+export interface Props {
+    tokensRecords: SofTokensRecord,
+}
+
+export default function SofTokensRecordEN(props: Props) {
+    return (
+        <>
+            <div><strong>Description</strong>: { props.tokensRecords.description }</div>
+            <div>Timestamp: { props.tokensRecords.addedOn }</div>
+            <div>Issuer: { props.tokensRecords.issuer }</div>
+            <SofFilesAndDeliveriesEN files={ props.tokensRecords.files } />
+        </>
+    )
+}

--- a/src/loc/statement/SofTokensRecordFR.tsx
+++ b/src/loc/statement/SofTokensRecordFR.tsx
@@ -1,0 +1,17 @@
+import { SofTokensRecord } from "./SofParams.js";
+import SofFilesAndDeliveriesFR from "./SofFilesAndDeliveriesFR";
+
+export interface Props {
+    tokensRecords: SofTokensRecord,
+}
+
+export default function SofTokensRecordFR(props: Props) {
+    return (
+        <>
+            <div><strong>Description</strong>: { props.tokensRecords.description }</div>
+            <div>Timestamp: { props.tokensRecords.addedOn }</div>
+            <div>Emetteur/Emettrice: { props.tokensRecords.issuer }</div>
+            <SofFilesAndDeliveriesFR files={ props.tokensRecords.files } />
+        </>
+    )
+}

--- a/src/loc/statement/StatementOfFactsTemplateEN.tsx
+++ b/src/loc/statement/StatementOfFactsTemplateEN.tsx
@@ -2,6 +2,8 @@ import { useEffect } from "react";
 import { loadPagedJs } from "./PagedJS";
 import { SofParams } from "./SofParams";
 import SofTermsAndConditionsEN from "./SofTermsAndConditionsEN";
+import SofTokensRecordEN from "./SofTokensRecordEN";
+import SofFilesAndDeliveriesEN from "./SofFilesAndDeliveriesEN";
 
 export interface Props {
     sofParams: SofParams;
@@ -147,34 +149,25 @@ export default function StatementOfFactsTemplateEN(props: Props) {
                     <div>Underlying Token ID: { props.sofParams.collectionItem.token.id }</div>
                     </>
                 }
-                {
-                    props.sofParams.collectionItem.files.map((file, index) => (
-                        <>
-                        <div className="section-name"><strong>Underlying asset #{index + 1}</strong></div>
-                        <div>Name: { file.name }</div>
-                        <div>Content Type: { file.contentType }</div>
-                        <div className="large-value">Hash: { file.hash }</div>
-                        <div>Size: { file.size.toString() } bytes</div>
-                        {
-                            file.deliveries.length > 0 &&
-                            <div>Claimed copies:</div>
-                        }
-                        {
-                            file.deliveries.map((delivery, deliveryIndex) => (
-                                <>
-                                <div className="large-value">Delivery #{ deliveryIndex + 1 } Copy Hash: { delivery.hash }</div>
-                                <div className="large-value">Delivery #{ deliveryIndex + 1 } Owner: { delivery.owner }</div>
-                                </>
-                            ))
-                        }
-                        </>
-                    ))
-                }
+                <SofFilesAndDeliveriesEN files={ props.sofParams.collectionItem.files } />
                 <SofTermsAndConditionsEN item={ props.sofParams.collectionItem } />
                 <hr/>
                 </>
             }
-
+            {
+                props.sofParams.tokensRecords.length > 0 &&
+                <>
+                    <h3 className="item-title">4 - Tokens Records</h3>
+                    {
+                        props.sofParams.tokensRecords.map((tokensRecord, i) => (
+                            <>
+                                { i > 0 && <hr /> }
+                                <SofTokensRecordEN tokensRecords={ tokensRecord } />
+                            </>
+                        ))
+                    }
+                </>
+            }
             <p className="conclusion-first">As I concluded my observations, I create the present Statement of Facts and
                 record it in the following Legal Officer Case: { props.sofParams.containingLocId } , a copy of which is
                 archived at my office location.</p>

--- a/src/loc/statement/StatementOfFactsTemplateFR.tsx
+++ b/src/loc/statement/StatementOfFactsTemplateFR.tsx
@@ -2,6 +2,8 @@ import { useEffect } from "react";
 import { loadPagedJs } from "./PagedJS";
 import { SofParams } from "./SofParams";
 import SofTermsAndConditionsFR from "./SofTermsAndConditionsFR";
+import SofTokensRecordFR from "./SofTokensRecordFR";
+import SofFilesAndDeliveriesFR from "./SofFilesAndDeliveriesFR";
 
 export interface Props {
     sofParams: SofParams;
@@ -147,34 +149,25 @@ export default function StatementOfFactsTemplateFR(props: Props) {
                     <div>ID du token sous-jacent: { props.sofParams.collectionItem.token.id }</div>
                     </>
                 }
-                {
-                    props.sofParams.collectionItem.files.map((file, index) => (
-                        <>
-                        <div className="section-name"><strong>Contenu sous-jacent #{index + 1}</strong></div>
-                        <div>Nom: { file.name }</div>
-                        <div>Type de contenu: { file.contentType }</div>
-                        <div className="large-value">Hash: { file.hash }</div>
-                        <div>Taille: { file.size.toString() } octets</div>
-                        {
-                            file.deliveries.length > 0 &&
-                            <div>Copies réclamées:</div>
-                        }
-                        {
-                            file.deliveries.map((delivery, deliveryIndex) => (
-                                <>
-                                <div className="large-value">Copie #{ deliveryIndex + 1 } - hash de la copie: { delivery.hash }</div>
-                                <div className="large-value">Copie #{ deliveryIndex + 1 } - détenteur: { delivery.owner }</div>
-                                </>
-                            ))
-                        }
-                        </>
-                    ))
-                }
+                <SofFilesAndDeliveriesFR files={ props.sofParams.collectionItem.files } />
                 <SofTermsAndConditionsFR item={ props.sofParams.collectionItem } />
                 <hr/>
                 </>
             }
-
+            {
+                props.sofParams.tokensRecords.length > 0 &&
+                <>
+                    <h3 className="item-title">4 - Enregistrements liés aux jetons</h3>
+                    {
+                        props.sofParams.tokensRecords.map((tokensRecord, i) => (
+                            <>
+                                { i > 0 && <hr /> }
+                                <SofTokensRecordFR tokensRecords={ tokensRecord } />
+                            </>
+                        ))
+                    }
+                </>
+            }
             <p className="conclusion-first">Mes constatations terminées, je dresse le présent Procés Verbal de constat
                 et l’enregistre dans le dossier numérique (Legal Officer Case) dont l’identifiant
                 est: { props.sofParams.containingLocId } et dont une copie est conservée au rang des minutes de l’étude.</p>


### PR DESCRIPTION
* Tokens records are now present in both EN and FR Statement of Facts.
* The layout of a file with its deliveries being the same for collection item and token records and is thus factored to a new component: `SofFilesAndDeliveries[FR|EN].jsx]`.

logion-network/logion-internal#802