### PR TITLE
Handle feedback

### DIFF
--- a/src/common/AmountFormat.tsx
+++ b/src/common/AmountFormat.tsx
@@ -1,10 +1,10 @@
 import { PrefixedNumber } from "@logion/node-api";
 
-export default function AmountFormat(props: { amount?: PrefixedNumber | undefined }) {
+export default function AmountFormat(props: { amount?: PrefixedNumber | undefined, decimals?: number }) {
 
     if(props.amount) {
         return (
-            <span>{ props.amount.coefficient.toFixedPrecision(2) + " " + props.amount.prefix.symbol }</span>
+            <span>{ props.amount.coefficient.toFixedPrecision(props.decimals || 2) + " " + props.amount.prefix.symbol }</span>
         );
     } else {
         return <span></span>

--- a/src/common/__snapshots__/TransactionStatusCell.test.tsx.snap
+++ b/src/common/__snapshots__/TransactionStatusCell.test.tsx.snap
@@ -133,7 +133,7 @@ Array [
                 </td>
                 <td>
                   <span>
-                    125.00 f
+                    0.0000 
                   </span>
                 </td>
               </tr>
@@ -143,7 +143,7 @@ Array [
                 </td>
                 <td>
                   <span>
-                    125.00 f
+                    0.0000 
                   </span>
                 </td>
               </tr>

--- a/src/loc/EstimatedFees.tsx
+++ b/src/loc/EstimatedFees.tsx
@@ -1,4 +1,4 @@
-import { Fees, LGNT_SMALLEST_UNIT, PrefixedNumber } from "@logion/node-api";
+import { Fees, LGNT_SMALLEST_UNIT, PrefixedNumber, NONE } from "@logion/node-api";
 import AmountFormat from "src/common/AmountFormat";
 import { customClassName } from "src/common/types/Helpers";
 import "./EstimatedFees.css";
@@ -7,6 +7,7 @@ export interface Props {
     fees: Fees | undefined | null;
     hideTitle?: boolean;
     centered?: boolean;
+    inclusionFeePaidBy?: string;
     storageFeePaidBy?: string;
 }
 
@@ -23,20 +24,35 @@ export default function EstimatedFees(props: Props) {
                 <tbody>
                     <tr>
                         <td>Blockchain record</td>
-                        <td><AmountFormat amount={ new PrefixedNumber(props.fees.inclusionFee.toString(), LGNT_SMALLEST_UNIT).optimizeScale(3) } /></td>
-                        { props.storageFeePaidBy !== undefined && <td></td> }
+                        <td>
+                            <AmountFormat
+                                amount={ new PrefixedNumber(props.fees.inclusionFee.toString(), LGNT_SMALLEST_UNIT).convertTo(NONE) }
+                                decimals={4}
+                            />
+                        </td>
+                        { (props.storageFeePaidBy !== undefined || props.inclusionFeePaidBy !== undefined) && <td>{ props.inclusionFeePaidBy || "" }</td> }
                     </tr>
                     { props.fees.storageFee !== undefined && 
                         <tr>
                             <td>File storage</td>
-                            <td><AmountFormat amount={ new PrefixedNumber(props.fees.storageFee.toString(), LGNT_SMALLEST_UNIT).optimizeScale(3) } /></td>
-                            { props.storageFeePaidBy !== undefined && <td>{ props.storageFeePaidBy }</td> }
+                            <td>
+                                <AmountFormat
+                                    amount={ new PrefixedNumber(props.fees.storageFee.toString(), LGNT_SMALLEST_UNIT).convertTo(NONE) }
+                                    decimals={4}
+                                />
+                            </td>
+                            { (props.storageFeePaidBy !== undefined || props.inclusionFeePaidBy !== undefined) && <td>{ props.storageFeePaidBy || "" }</td> }
                         </tr>
                     }
                     <tr>
                         <td>Total</td>
-                        <td><AmountFormat amount={ new PrefixedNumber(props.fees.totalFee.toString(), LGNT_SMALLEST_UNIT).optimizeScale(3) } /></td>
-                        { props.storageFeePaidBy !== undefined && <td></td> }
+                        <td>
+                            <AmountFormat
+                                amount={ new PrefixedNumber(props.fees.totalFee.toString(), LGNT_SMALLEST_UNIT).convertTo(NONE) }
+                                decimals={4}
+                            />
+                        </td>
+                        { (props.storageFeePaidBy !== undefined || props.inclusionFeePaidBy !== undefined) && <td></td> }
                     </tr>
                 </tbody>
             </table>

--- a/src/loc/LocPrivateFileDetails.tsx
+++ b/src/loc/LocPrivateFileDetails.tsx
@@ -50,7 +50,8 @@ export default function LocPrivateFileDetails(props: Props) {
                                     fees={ props.item.fees }
                                     centered={ false }
                                     hideTitle={ true }
-                                    storageFeePaidBy={ props.storageFeePaidByRequester ? "paid by requester" : "paid by owner" }
+                                    inclusionFeePaidBy="paid by Legal Officer"
+                                    storageFeePaidBy={ props.storageFeePaidByRequester ? "paid by requester" : "paid by Legal Officer" }
                                 />
                             </LocItemDetail>
                         </>

--- a/src/loc/__snapshots__/EstimatedFees.test.tsx.snap
+++ b/src/loc/__snapshots__/EstimatedFees.test.tsx.snap
@@ -18,20 +18,21 @@ exports[`EstimatedFees renders fees with storage 1`] = `
             amount={
               PrefixedNumber {
                 "_prefix": Object {
-                  "symbol": "a",
-                  "tenExponent": -18,
+                  "symbol": "",
+                  "tenExponent": 0,
                 },
                 "_scientificNumber": ScientificNumber {
                   "_normalized": NormalizedNumber {
-                    "_decimalPart": "",
-                    "_integerPart": "42",
+                    "_decimalPart": "0000000000000000042",
+                    "_integerPart": "",
                     "_negative": false,
-                    "_normalized": "42.",
+                    "_normalized": ".0000000000000000042",
                   },
-                  "_tenExponent": -18,
+                  "_tenExponent": 0,
                 },
               }
             }
+            decimals={4}
           />
         </td>
       </tr>
@@ -44,20 +45,21 @@ exports[`EstimatedFees renders fees with storage 1`] = `
             amount={
               PrefixedNumber {
                 "_prefix": Object {
-                  "symbol": "a",
-                  "tenExponent": -18,
+                  "symbol": "",
+                  "tenExponent": 0,
                 },
                 "_scientificNumber": ScientificNumber {
                   "_normalized": NormalizedNumber {
-                    "_decimalPart": "",
-                    "_integerPart": "32",
+                    "_decimalPart": "0000000000000000032",
+                    "_integerPart": "",
                     "_negative": false,
-                    "_normalized": "32.",
+                    "_normalized": ".0000000000000000032",
                   },
-                  "_tenExponent": -18,
+                  "_tenExponent": 0,
                 },
               }
             }
+            decimals={4}
           />
         </td>
       </tr>
@@ -70,20 +72,21 @@ exports[`EstimatedFees renders fees with storage 1`] = `
             amount={
               PrefixedNumber {
                 "_prefix": Object {
-                  "symbol": "a",
-                  "tenExponent": -18,
+                  "symbol": "",
+                  "tenExponent": 0,
                 },
                 "_scientificNumber": ScientificNumber {
                   "_normalized": NormalizedNumber {
-                    "_decimalPart": "",
-                    "_integerPart": "74",
+                    "_decimalPart": "0000000000000000074",
+                    "_integerPart": "",
                     "_negative": false,
-                    "_normalized": "74.",
+                    "_normalized": ".0000000000000000074",
                   },
-                  "_tenExponent": -18,
+                  "_tenExponent": 0,
                 },
               }
             }
+            decimals={4}
           />
         </td>
       </tr>
@@ -110,20 +113,21 @@ exports[`EstimatedFees renders fees without storage 1`] = `
             amount={
               PrefixedNumber {
                 "_prefix": Object {
-                  "symbol": "a",
-                  "tenExponent": -18,
+                  "symbol": "",
+                  "tenExponent": 0,
                 },
                 "_scientificNumber": ScientificNumber {
                   "_normalized": NormalizedNumber {
-                    "_decimalPart": "",
-                    "_integerPart": "42",
+                    "_decimalPart": "0000000000000000042",
+                    "_integerPart": "",
                     "_negative": false,
-                    "_normalized": "42.",
+                    "_normalized": ".0000000000000000042",
                   },
-                  "_tenExponent": -18,
+                  "_tenExponent": 0,
                 },
               }
             }
+            decimals={4}
           />
         </td>
       </tr>
@@ -136,20 +140,21 @@ exports[`EstimatedFees renders fees without storage 1`] = `
             amount={
               PrefixedNumber {
                 "_prefix": Object {
-                  "symbol": "a",
-                  "tenExponent": -18,
+                  "symbol": "",
+                  "tenExponent": 0,
                 },
                 "_scientificNumber": ScientificNumber {
                   "_normalized": NormalizedNumber {
-                    "_decimalPart": "",
-                    "_integerPart": "42",
+                    "_decimalPart": "0000000000000000042",
+                    "_integerPart": "",
                     "_negative": false,
-                    "_normalized": "42.",
+                    "_normalized": ".0000000000000000042",
                   },
-                  "_tenExponent": -18,
+                  "_tenExponent": 0,
                 },
               }
             }
+            decimals={4}
           />
         </td>
       </tr>


### PR DESCRIPTION
* See comments starting from https://github.com/logion-network/logion-internal/issues/824#issuecomment-1490574105
* Fees are now expressed in LGNT units.
* Fees are represented with 4 decimals.
* "paid by Legal Officer" was added to fees table next to inclusion fee (Blockchain record).

logion-network/logion-internal#824