### PR TITLE
Manual activation of MetaMask

### DIFF
--- a/src/Login.css
+++ b/src/Login.css
@@ -53,13 +53,25 @@
     margin-right: 60px;
 }
 
+.Login .extensions-container {
+    text-align: center;
+    position: relative;
+    z-index: 1;
+    padding-top: 3rem;
+    padding-bottom: 2rem;
+}
+
+.Login .extensions-container .metamask img {
+    margin-right: 10px;
+}
+
 .Login .node-info {
     text-align: center;
     margin-bottom: 60px;
 }
 
 .Login .node-info .name {
-    font-size: 1.7rem;
+    font-size: 1.2rem;
     font-weight: bold;
 }
 

--- a/src/Login.tsx
+++ b/src/Login.tsx
@@ -12,6 +12,7 @@ import AbsoluteLogo from './AbsoluteLogo';
 
 import './Login.css';
 import Icon from "./common/Icon";
+import Alert from "./common/Alert";
 
 export const LOGIN_PATH = "/login";
 
@@ -31,12 +32,18 @@ function referrer(location: Location): string {
 export default function Login() {
     const location = useLocation();
     const navigate = useNavigate();
-    const { connectedNodeMetadata, accounts, authenticate } = useLogionChain();
+    const { connectedNodeMetadata, accounts, authenticate, tryEnableMetaMask, metaMaskAccounts } = useLogionChain();
     const [ selectedAddresses, setSelectedAddresses ] = useState<ValidAccountId[]>([]);
+    const [ error, setError ] = useState<string>();
 
     const startLogin = useCallback(async () => {
-        await authenticate(selectedAddresses);
-        navigate(referrer(location));
+        setError(undefined);
+        try {
+            await authenticate(selectedAddresses);
+            navigate(referrer(location));
+        } catch(e) {
+            setError((e as Error).message);
+        }
     }, [ selectedAddresses, navigate, location, authenticate ]);
 
     if(accounts === null || connectedNodeMetadata === null) {
@@ -97,6 +104,27 @@ export default function Login() {
                         onClick={ startLogin }
                     >
                         Log in
+                    </Button>
+
+                    {
+                        error !== undefined &&
+                        <Alert
+                            variant="warning_color"
+                        >
+                            { error }
+                        </Alert>
+                    }
+                </div>
+
+                <div className="extensions-container">
+                    <h2>You do not see your account?</h2>
+
+                    <Button
+                        className="metamask"
+                        disabled={ metaMaskAccounts !== null }
+                        onClick={ tryEnableMetaMask }
+                    >
+                       <Icon icon={{ id: "metamask" }} height="30px" /> Try with MetaMask
                     </Button>
                 </div>
 

--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -21,27 +21,35 @@ export default function Main() {
 }
 
 export function AuthenticatedMain() {
-    const { injectedAccounts, extensionsEnabled } = useLogionChain();
+    const { injectedAccounts, extensionsEnabled, accounts } = useLogionChain();
 
     if (!extensionsEnabled) {
         return <Loader text="Enabling extensions..." />;
     } else {
-        if (isExtensionAvailable()) {
-            if (injectedAccounts === null) {
-                return <Loader text="Loading accounts from extension..." />;
-            } else {
-                if (injectedAccounts.length > 0) {
-                    return (
-                        <CommonContextProvider>
-                            <RootRouter />
-                        </CommonContextProvider>
-                    );
-                } else {
-                    return <LandingPage activeStep="create" />;
-                }
-            }
+        if (accounts !== null && accounts.all.length > 0) {
+            return (
+                <CommonContextProvider>
+                    <RootRouter />
+                </CommonContextProvider>
+            );
         } else {
-            return <LandingPage activeStep="install" />;
+            if (isExtensionAvailable()) {
+                if (injectedAccounts === null) {
+                    return <Loader text="Loading accounts from extension..." />;
+                } else {
+                    if (injectedAccounts.length > 0) {
+                        return (
+                            <CommonContextProvider>
+                                <RootRouter />
+                            </CommonContextProvider>
+                        );
+                    } else {
+                        return <LandingPage activeStep="create" />;
+                    }
+                }
+            } else {
+                return <LandingPage activeStep="install" />;
+            }
         }
     }
 }

--- a/src/__snapshots__/Login.test.tsx.snap
+++ b/src/__snapshots__/Login.test.tsx.snap
@@ -66,6 +66,27 @@ exports[`Login renders 1`] = `
       </Button>
     </div>
     <div
+      className="extensions-container"
+    >
+      <h2>
+        You do not see your account?
+      </h2>
+      <Button
+        className="metamask"
+        disabled={true}
+      >
+        <Icon
+          height="30px"
+          icon={
+            Object {
+              "id": "metamask",
+            }
+          }
+        />
+         Try with MetaMask
+      </Button>
+    </div>
+    <div
       className="node-info"
     >
       <p

--- a/src/landing/LandingPage.tsx
+++ b/src/landing/LandingPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import Container from 'react-bootstrap/Container';
 import Row from 'react-bootstrap/Row';
 import Col from 'react-bootstrap/Col';
@@ -11,6 +11,7 @@ import AbsoluteLogo from '../AbsoluteLogo';
 
 import './LandingPage.css';
 import { Tutorial } from './Tutorial';
+import { useLogionChain } from '../logion-chain';
 
 export interface Props {
     activeStep: Step,
@@ -21,6 +22,7 @@ export type Step = 'install' | 'create';
 type DialogType = 'install' | 'create' | 'recover' | null;
 
 export default function LandingPage(props: Props) {
+    const { tryEnableMetaMask } = useLogionChain();
     const [ showDialog, setShowDialog ] = useState<DialogType>(null);
 
     let stepsLeft;
@@ -32,6 +34,10 @@ export default function LandingPage(props: Props) {
         stepsLeft = 1;
     }
 
+    const loginWithMetaMask = useCallback(async () => {
+        await tryEnableMetaMask();
+    }, []);
+
     return (
         <div className="LandingPage">
             <Container fluid className="header-container">
@@ -41,6 +47,7 @@ export default function LandingPage(props: Props) {
                         <div className="call">
                             <span className="first">You are only { stepsLeft } (simple) steps away</span>
                             <span className="second">from your logion legal protection</span>
+                            <span className="third">(Using MetaMask? Click <Button variant="link" slim narrow onClick={ loginWithMetaMask }>here</Button>)</span>
                         </div>
                     </header>
                 </Container>

--- a/src/landing/LandingPage.tsx
+++ b/src/landing/LandingPage.tsx
@@ -36,7 +36,7 @@ export default function LandingPage(props: Props) {
 
     const loginWithMetaMask = useCallback(async () => {
         await tryEnableMetaMask();
-    }, []);
+    }, [ tryEnableMetaMask ]);
 
     return (
         <div className="LandingPage">

--- a/src/landing/__snapshots__/LandingPage.test.tsx.snap
+++ b/src/landing/__snapshots__/LandingPage.test.tsx.snap
@@ -28,6 +28,20 @@ exports[`renders create 1`] = `
           >
             from your logion legal protection
           </span>
+          <span
+            className="third"
+          >
+            (Using MetaMask? Click 
+            <Button
+              narrow={true}
+              onClick={[Function]}
+              slim={true}
+              variant="link"
+            >
+              here
+            </Button>
+            )
+          </span>
         </div>
       </header>
     </Container>
@@ -560,6 +574,20 @@ exports[`renders install 1`] = `
             className="second"
           >
             from your logion legal protection
+          </span>
+          <span
+            className="third"
+          >
+            (Using MetaMask? Click 
+            <Button
+              narrow={true}
+              onClick={[Function]}
+              slim={true}
+              variant="link"
+            >
+              here
+            </Button>
+            )
           </span>
         </div>
       </header>


### PR DESCRIPTION
* A button was added on login screen to explicitly activate MetaMask (which is no more automatically enabled by default).
* It is now possible to go to login screen from landing page by activating MetaMask only.
* Login failures are now properly reported to user.

logion-network/logion-internal#972