### PR TITLE
Call async isExtensionAvailable()

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "@craco/craco": "^6.4.5",
         "@creativecommons/cc-assets": "^0.1.0",
         "@logion/crossmint": "^0.1.23-1",
-        "@logion/extension": "^0.5.21-1",
+        "@logion/extension": "^0.5.21-4",
         "@logion/multiversx": "^0.1.4-1",
         "@multiversx/sdk-extension-provider": "^2.0.7",
         "@popperjs/core": "^2.11.6",

--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -8,6 +8,8 @@ import { CommonContextProvider } from './common/CommonContext';
 import { Routes, BrowserRouter as Router, Route } from "react-router-dom";
 import PublicRouter from "./PublicRouter";
 import { PUBLIC_PATH } from "./PublicPaths";
+import config from "./config";
+import { useState, useEffect } from "react";
 
 export default function Main() {
     return (
@@ -22,8 +24,16 @@ export default function Main() {
 
 export function AuthenticatedMain() {
     const { injectedAccounts, extensionsEnabled, accounts } = useLogionChain();
+    const [ extensionAvailable, setExtensionAvailable ] = useState<boolean>();
 
-    if (!extensionsEnabled) {
+    useEffect(() => {
+        if (extensionAvailable === undefined) {
+            isExtensionAvailable(config.APP_NAME)
+                .then(setExtensionAvailable);
+        }
+    }, [ extensionAvailable ]);
+
+    if (!extensionsEnabled || extensionAvailable === undefined) {
         return <Loader text="Enabling extensions..." />;
     } else {
         if (accounts !== null && accounts.all.length > 0) {
@@ -33,7 +43,7 @@ export function AuthenticatedMain() {
                 </CommonContextProvider>
             );
         } else {
-            if (isExtensionAvailable()) {
+            if (extensionAvailable) {
                 if (injectedAccounts === null) {
                     return <Loader text="Loading accounts from extension..." />;
                 } else {

--- a/src/logion-chain/LogionChainContext.tsx
+++ b/src/logion-chain/LogionChainContext.tsx
@@ -1,5 +1,20 @@
-import { AccountTokens, LegalOfficer, LegalOfficerClass, LogionClient, DefaultSignAndSendStrategy, Token, RawSigner } from '@logion/client';
-import { allMetamaskAccounts, enableExtensions, enableMetaMask, ExtensionSigner, InjectedAccount, isExtensionAvailable } from '@logion/extension';
+import {
+    AccountTokens,
+    LegalOfficer,
+    LegalOfficerClass,
+    LogionClient,
+    DefaultSignAndSendStrategy,
+    Token,
+    RawSigner
+} from '@logion/client';
+import {
+    allMetamaskAccounts,
+    enableExtensions,
+    enableMetaMask,
+    ExtensionSigner,
+    InjectedAccount,
+    isExtensionAvailable
+} from '@logion/extension';
 import { buildApiClass, LogionNodeApiClass, ValidAccountId } from '@logion/node-api';
 import axios, { AxiosInstance } from 'axios';
 import React, { useReducer, useContext, Context, Reducer, useEffect, useCallback } from 'react';
@@ -7,7 +22,14 @@ import { DateTime } from 'luxon';
 
 import config, { Node } from '../config';
 import Accounts, { buildAccounts, toValidAccountId } from '../common/types/Accounts';
-import { clearAll, clearCurrentAddress, loadCurrentAddress, loadTokens, storeCurrentAddress, storeTokens } from '../common/Storage';
+import {
+    clearAll,
+    clearCurrentAddress,
+    loadCurrentAddress,
+    loadTokens,
+    storeCurrentAddress,
+    storeTokens
+} from '../common/Storage';
 
 import { getEndpoints, NodeMetadata } from './Connection';
 
@@ -329,7 +351,7 @@ async function consumeInjectedAccounts(state: LogionChainContextType, dispatch: 
     } else if(state.injectedAccountsConsumptionState === 'STARTING') {
         dispatch({type: 'INJECTED_ACCOUNTS_CONSUMPTION_STARTED'});
 
-        if(isExtensionAvailable()) {
+        if(await isExtensionAvailable(config.APP_NAME)) {
             const register = await enableExtensions(config.APP_NAME);
             dispatch({
                 type: 'EXTENSIONS_ENABLED',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2976,7 +2976,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@logion/client@npm:^0.30.0-1":
+"@logion/client@npm:^0.30.0-1, @logion/client@npm:^0.30.0-7":
   version: 0.30.0-7
   resolution: "@logion/client@npm:0.30.0-7"
   dependencies:
@@ -2998,14 +2998,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@logion/extension@npm:^0.5.21-1":
-  version: 0.5.21-1
-  resolution: "@logion/extension@npm:0.5.21-1"
+"@logion/extension@npm:^0.5.21-4":
+  version: 0.5.21-4
+  resolution: "@logion/extension@npm:0.5.21-4"
   dependencies:
-    "@logion/client": ^0.30.0-1
+    "@logion/client": ^0.30.0-7
     "@polkadot/extension-compat-metamask": ^0.46.5
     "@polkadot/extension-dapp": ^0.46.5
-  checksum: beaeb3f77aab05f4d0ffd567ab3835e3e9ab62b76be24a1508a80b9021cf3f49820835fcf5c3116025d992bcbd3c043bdf40a705809fa153319b836d9e46ca61
+  checksum: 194c8ecf54a42b320de9c7ff1c4af2286a472a90ff8ef7f26af3d08605b7d81a1642897e80cb627d49357cf07871f1dedb632d8c639b1c58d56b1ed8677d340c
   languageName: node
   linkType: hard
 
@@ -12562,7 +12562,7 @@ __metadata:
     "@craco/craco": ^6.4.5
     "@creativecommons/cc-assets": ^0.1.0
     "@logion/crossmint": ^0.1.23-1
-    "@logion/extension": ^0.5.21-1
+    "@logion/extension": ^0.5.21-4
     "@logion/multiversx": ^0.1.4-1
     "@multiversx/sdk-extension-provider": ^2.0.7
     "@popperjs/core": ^2.11.6


### PR DESCRIPTION
* Call new async `isExtensionAvailable()`
* This avoids the problem of the Polkadot extension not being detected under Firefox.
* Unfortunately in Firefox the first call returns (very often) false, thus briefly showing the 3-steps extension installation screen.

logion-network/logion-internal#973