### PR TITLE
Enable custom legal fees

### DIFF
--- a/src/common/AmountControl.tsx
+++ b/src/common/AmountControl.tsx
@@ -15,8 +15,8 @@ export interface Props {
     placeholder?: string;
 }
 
-export function validateAmount(amount: Amount): string | undefined {
-    if(amount.value === "" || isNaN(Number(amount.value))) {
+export function validateAmount(amount: Amount | undefined): string | undefined {
+    if(amount !== undefined && amount !== null && (amount.value === "" || isNaN(Number(amount.value)))) {
         return "Invalid amount";
     } else {
         return undefined;
@@ -26,18 +26,18 @@ export function validateAmount(amount: Amount): string | undefined {
 export default function AmountControl(props: Props) {
 
     const onChangeValue = useCallback((value: string) => {
-        if(props.value && props.onChange) {
+        if(props.onChange) {
             props.onChange({
                 value,
-                unit: props.value.unit
+                unit: props.value?.unit || Numbers.NONE,
             });
         }
     }, [ props ]);
 
     const onChangeUnit = useCallback((unit: Numbers.UnitPrefix) => {
-        if(props.value && props.onChange) {
+        if(props.onChange) {
             props.onChange({
-                value: props.value.value,
+                value: props.value?.value || "0",
                 unit
             });
         }

--- a/src/common/TransactionType.tsx
+++ b/src/common/TransactionType.tsx
@@ -34,7 +34,7 @@ const palletLogionLocMethods: Record<LogionLocMethod, string> = {
     createLogionTransactionLoc: "Logion Identity LOC created",
     createOtherIdentityLoc: "Other Identity LOC created",
     createPolkadotIdentityLoc: "Polkadot Identity LOC created",
-    createPolkadotTransactionLoc: "Polkadot Identity LOC created",
+    createPolkadotTransactionLoc: "Polkadot Transaction LOC created",
     makeVoid: "LOC voided",
     makeVoidAndReplace: "LOC voided and replaced",
     addTokensRecord: "Tokens record added",

--- a/src/common/Wallet.tsx
+++ b/src/common/Wallet.tsx
@@ -56,7 +56,7 @@ export function Content(props: Props & { type: WalletType }) {
     const navigate = useNavigate();
     const { width } = useResponsiveContext();
 
-    if(balances === null || transactions === null) {
+    if(balances === null || balances.length === 0 || transactions === null) {
         return <Loader />;
     }
 

--- a/src/components/collapsepane/CollapsePane.css
+++ b/src/components/collapsepane/CollapsePane.css
@@ -1,0 +1,7 @@
+.CollapsePane .control {
+    text-align: left;
+}
+
+.CollapsePane .pane {
+    padding-top: 30px;
+}

--- a/src/components/collapsepane/CollapsePane.tsx
+++ b/src/components/collapsepane/CollapsePane.tsx
@@ -1,0 +1,36 @@
+import { useState } from "react";
+import { Collapse } from "react-bootstrap";
+
+import "./CollapsePane.css";
+import Button from "src/common/Button";
+
+export interface Props {
+    children: React.ReactNode;
+    title: string;
+}
+
+export default function CollapsePane(props: Props) {
+    const [ open, setOpen ] = useState(false);
+
+    return (
+        <div className="CollapsePane">
+            <div className="control">
+                <Button
+                    onClick={ () => setOpen(!open) }
+                    variant="link"
+                    slim
+                    narrow
+                >
+                    { props.title } [{ open ? "-" : "+" }]
+                </Button>
+            </div>
+            <Collapse
+                in={open}
+            >
+                <div className="pane">
+                    { props.children }
+                </div>
+            </Collapse>
+        </div>
+    );
+}

--- a/src/components/identity/CollectionInfo.tsx
+++ b/src/components/identity/CollectionInfo.tsx
@@ -1,13 +1,13 @@
 import { LocData } from "@logion/client";
 import { Currency } from "@logion/node-api";
+import { Row, Col } from "react-bootstrap";
 
-import { Row } from "../../common/Grid";
-import { Col } from "react-bootstrap";
 import Detail from "../../common/Detail";
 
 import "./CollectionInfo.css";
 import AmountFormat from "src/common/AmountFormat";
 import { toPrefixedLgnt } from "src/common/AmountCell";
+import LegalFeeAmount from "src/loc/LegalFeeAmount";
 
 export interface Props {
     collection: LocData;
@@ -23,6 +23,9 @@ export function CollectionInfo(props: Props) {
                         <AmountFormat amount={
                             props.collection.valueFee ? toPrefixedLgnt(props.collection.valueFee.toString()) : Currency.nLgnt(0n)
                         }/> { Currency.SYMBOL }</span> } />
+                </Col>
+                <Col>
+                    <Detail label="Legal fee" value={ <LegalFeeAmount loc={ props.collection } />} />
                 </Col>
             </Row>
         </div>

--- a/src/legal-officer/transaction-protection/LocRequestAcceptanceAndCreation.test.tsx
+++ b/src/legal-officer/transaction-protection/LocRequestAcceptanceAndCreation.test.tsx
@@ -39,7 +39,7 @@ describe("LocRequestAcceptance", () => {
 
         setupApiMock(api => {
             const submittable = mockSubmittable();
-            api.setup(instance => instance.polkadot.tx.logionLoc.createPolkadotTransactionLoc(It.IsAny(), It.IsAny())).returns(submittable.object());
+            api.setup(instance => instance.polkadot.tx.logionLoc.createPolkadotTransactionLoc(It.IsAny(), It.IsAny(), null)).returns(submittable.object());
             const fees = new Mock<Fees>();
             api.setup(instance => instance.fees.estimateCreateLoc(It.IsAny())).returnsAsync(fees.object());
         });
@@ -70,7 +70,7 @@ describe("LocRequestAcceptance", () => {
 
         setupApiMock(api => {
             const submittable = mockSubmittable();
-            api.setup(instance => instance.polkadot.tx.logionLoc.createCollectionLoc(It.IsAny(), It.IsAny(), It.IsAny(), It.IsAny(), It.IsAny(), It.IsAny())).returns(submittable.object());
+            api.setup(instance => instance.polkadot.tx.logionLoc.createCollectionLoc(It.IsAny(), It.IsAny(), It.IsAny(), It.IsAny(), It.IsAny(), It.IsAny(), null)).returns(submittable.object());
             const fees = new Mock<Fees>();
             api.setup(instance => instance.fees.estimateCreateLoc(It.IsAny())).returnsAsync(fees.object());
         });

--- a/src/loc/AcceptRejectLocRequest.test.tsx
+++ b/src/loc/AcceptRejectLocRequest.test.tsx
@@ -1,5 +1,5 @@
 import { LocData } from "@logion/client";
-import { UUID, Fees } from "@logion/node-api";
+import { UUID } from "@logion/node-api";
 import { getByText, render, screen, waitFor } from "@testing-library/react";
 import userEvent from '@testing-library/user-event';
 
@@ -7,8 +7,7 @@ import { setCurrentAddress, DEFAULT_LEGAL_OFFICER_ACCOUNT } from '../logion-chai
 import { shallowRender } from "../tests";
 import AcceptRejectLocRequest from "./AcceptRejectLocRequest";
 import "./AcceptRejectLocRequest.tsx";
-import { mockSubmittable, mockValidPolkadotAccountId, setupApiMock } from 'src/__mocks__/LogionMock';
-import { It, Mock } from "moq.ts";
+import { mockValidPolkadotAccountId } from 'src/__mocks__/LogionMock';
 
 jest.mock("../logion-chain");
 jest.mock('./Model');
@@ -50,12 +49,6 @@ describe("AcceptRejectLocRequest", () => {
     });
 
     it("opens acceptance process when click on accept", async () => {
-        setupApiMock(api => {
-            const submittable = mockSubmittable();
-            api.setup(instance => instance.polkadot.tx.logionLoc.createPolkadotTransactionLoc(It.IsAny(), It.IsAny())).returns(submittable.object());
-            const fees = new Mock<Fees>();
-            api.setup(instance => instance.fees.estimateCreateLoc(It.IsAny())).returnsAsync(fees.object());
-        });
         const tree = render(<AcceptRejectLocRequest loc={{
             id: new UUID(REQUEST_ID),
             legalOfficerAddress: "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",

--- a/src/loc/LegalFeeAmount.tsx
+++ b/src/loc/LegalFeeAmount.tsx
@@ -1,0 +1,36 @@
+import { LocData } from "@logion/client";
+import { Currency } from "@logion/node-api";
+
+import "./TransactionInfo.css";
+import AmountFormat from "src/common/AmountFormat";
+import { toPrefixedLgnt } from "src/common/AmountCell";
+import { useMemo } from "react";
+
+export interface Props {
+    loc: LocData;
+}
+
+const DEFAULT_LEGAL_FEE = 2000n;
+
+export default function LegalFeeAmount(props: Props) {
+
+    const legalFee = useMemo(() => {
+        if(props.loc.requesterLocId) {
+            return { value: 0n, custom: true };
+        } else {
+            if(props.loc.legalFee !== undefined) {
+                return { value: props.loc.legalFee, custom: true };
+            } else {
+                return { value: Currency.toCanonicalAmount(Currency.nLgnt(DEFAULT_LEGAL_FEE)), custom: false };
+            }
+        }
+    }, [ props.loc ]);
+
+    return (
+        <span>
+            <AmountFormat amount={
+                toPrefixedLgnt(legalFee.value.toString())
+            }/>{ Currency.SYMBOL }{ legalFee.custom ? "" : " (default fee)" }
+        </span>
+    )
+}

--- a/src/loc/LocDetailsTab.tsx
+++ b/src/loc/LocDetailsTab.tsx
@@ -31,6 +31,7 @@ import { canAdd, getLinkData, LinkData, LocItem } from "./LocItem";
 import { createDocumentTemplateItem, createLinkTemplateItem, createMetadataTemplateItem } from "./LocItemFactory";
 import { useLogionChain } from "src/logion-chain";
 import { CollectionInfo } from "src/components/identity/CollectionInfo";
+import { TransactionInfo } from "./TransactionInfo";
 
 export interface Props {
     loc: LocData;
@@ -308,6 +309,13 @@ export function LocDetailsTabContent(props: ContentProps) {
             <>
             <div className="separator" style={ { backgroundColor: locTabBorderColor } } />
             <CollectionInfo collection={ loc } />
+            </>
+        }
+        {
+            loc.locType === "Transaction" &&
+            <>
+            <div className="separator" style={ { backgroundColor: locTabBorderColor } } />
+            <TransactionInfo loc={ loc } />
             </>
         }
         <div className="separator" style={ { backgroundColor: locTabBorderColor } } />

--- a/src/loc/TransactionInfo.css
+++ b/src/loc/TransactionInfo.css
@@ -1,0 +1,10 @@
+.TransactionInfo .title {
+    font-weight: bold;
+    font-size: 1.2rem;
+    margin-bottom: 20px;
+}
+
+.TransactionInfo .Detail .label {
+    font-weight: bold;
+    font-size: 0.9rem;
+}

--- a/src/loc/TransactionInfo.tsx
+++ b/src/loc/TransactionInfo.tsx
@@ -1,0 +1,25 @@
+import { LocData } from "@logion/client";
+import { Row, Col } from "react-bootstrap";
+
+import Detail from "../common/Detail";
+
+import "./TransactionInfo.css";
+import LegalFeeAmount from "./LegalFeeAmount";
+
+export interface Props {
+    loc: LocData;
+}
+
+export function TransactionInfo(props: Props) {
+
+    return (
+        <div className="TransactionInfo">
+            <p className="title">Transaction parameters</p>
+            <Row>
+                <Col>
+                    <Detail label="Legal fee" value={ <LegalFeeAmount loc={ props.loc } />} />
+                </Col>
+            </Row>
+        </div>
+    )
+}

--- a/src/loc/__snapshots__/LocDetailsTab.test.tsx.snap
+++ b/src/loc/__snapshots__/LocDetailsTab.test.tsx.snap
@@ -309,6 +309,47 @@ exports[`LocDetailsTabContent renders closed data LOC for LO 1`] = `
       />
     </Col>
   </Row>
+  <React.Fragment>
+    <div
+      className="separator"
+      style={
+        Object {
+          "backgroundColor": "black",
+        }
+      }
+    />
+    <TransactionInfo
+      loc={
+        Object {
+          "closed": true,
+          "closedOn": "2022-09-28T08:49:00.000+02:00",
+          "createdOn": "2022-09-28T07:49:00.000+02:00",
+          "id": UUID {
+            "bytes": Uint8Array [
+              240,
+              175,
+              187,
+              187,
+              105,
+              109,
+              75,
+              119,
+              129,
+              112,
+              119,
+              229,
+              101,
+              136,
+              138,
+              14,
+            ],
+          },
+          "locType": "Transaction",
+          "status": "CLOSED",
+        }
+      }
+    />
+  </React.Fragment>
   <div
     className="separator"
     style={
@@ -521,6 +562,47 @@ exports[`LocDetailsTabContent renders closed data LOC for User 1`] = `
       />
     </Col>
   </Row>
+  <React.Fragment>
+    <div
+      className="separator"
+      style={
+        Object {
+          "backgroundColor": "black",
+        }
+      }
+    />
+    <TransactionInfo
+      loc={
+        Object {
+          "closed": true,
+          "closedOn": "2022-09-28T08:49:00.000+02:00",
+          "createdOn": "2022-09-28T07:49:00.000+02:00",
+          "id": UUID {
+            "bytes": Uint8Array [
+              240,
+              175,
+              187,
+              187,
+              105,
+              109,
+              75,
+              119,
+              129,
+              112,
+              119,
+              229,
+              101,
+              136,
+              138,
+              14,
+            ],
+          },
+          "locType": "Transaction",
+          "status": "CLOSED",
+        }
+      }
+    />
+  </React.Fragment>
   <div
     className="separator"
     style={
@@ -717,6 +799,47 @@ exports[`LocDetailsTabContent renders open data LOC for LO 1`] = `
       />
     </Col>
   </Row>
+  <React.Fragment>
+    <div
+      className="separator"
+      style={
+        Object {
+          "backgroundColor": "black",
+        }
+      }
+    />
+    <TransactionInfo
+      loc={
+        Object {
+          "closed": false,
+          "closedOn": undefined,
+          "createdOn": "2022-09-28T07:49:00.000+02:00",
+          "id": UUID {
+            "bytes": Uint8Array [
+              240,
+              175,
+              187,
+              187,
+              105,
+              109,
+              75,
+              119,
+              129,
+              112,
+              119,
+              229,
+              101,
+              136,
+              138,
+              14,
+            ],
+          },
+          "locType": "Transaction",
+          "status": "OPEN",
+        }
+      }
+    />
+  </React.Fragment>
   <div
     className="separator"
     style={
@@ -936,6 +1059,47 @@ exports[`LocDetailsTabContent renders open data LOC for User 1`] = `
       />
     </Col>
   </Row>
+  <React.Fragment>
+    <div
+      className="separator"
+      style={
+        Object {
+          "backgroundColor": "black",
+        }
+      }
+    />
+    <TransactionInfo
+      loc={
+        Object {
+          "closed": false,
+          "closedOn": undefined,
+          "createdOn": "2022-09-28T07:49:00.000+02:00",
+          "id": UUID {
+            "bytes": Uint8Array [
+              240,
+              175,
+              187,
+              187,
+              105,
+              109,
+              75,
+              119,
+              129,
+              112,
+              119,
+              229,
+              101,
+              136,
+              138,
+              14,
+            ],
+          },
+          "locType": "Transaction",
+          "status": "OPEN",
+        }
+      }
+    />
+  </React.Fragment>
   <div
     className="separator"
     style={
@@ -1404,6 +1568,48 @@ exports[`LocDetailsTabContent renders void data LOC for LO 1`] = `
       />
     </Col>
   </Row>
+  <React.Fragment>
+    <div
+      className="separator"
+      style={
+        Object {
+          "backgroundColor": "black",
+        }
+      }
+    />
+    <TransactionInfo
+      loc={
+        Object {
+          "closed": false,
+          "closedOn": undefined,
+          "createdOn": "2022-09-28T07:49:00.000+02:00",
+          "id": UUID {
+            "bytes": Uint8Array [
+              240,
+              175,
+              187,
+              187,
+              105,
+              109,
+              75,
+              119,
+              129,
+              112,
+              119,
+              229,
+              101,
+              136,
+              138,
+              14,
+            ],
+          },
+          "locType": "Transaction",
+          "status": "OPEN",
+          "voidInfo": Object {},
+        }
+      }
+    />
+  </React.Fragment>
   <div
     className="separator"
     style={
@@ -1607,6 +1813,48 @@ exports[`LocDetailsTabContent renders void data LOC for User 1`] = `
       />
     </Col>
   </Row>
+  <React.Fragment>
+    <div
+      className="separator"
+      style={
+        Object {
+          "backgroundColor": "black",
+        }
+      }
+    />
+    <TransactionInfo
+      loc={
+        Object {
+          "closed": false,
+          "closedOn": undefined,
+          "createdOn": "2022-09-28T07:49:00.000+02:00",
+          "id": UUID {
+            "bytes": Uint8Array [
+              240,
+              175,
+              187,
+              187,
+              105,
+              109,
+              75,
+              119,
+              129,
+              112,
+              119,
+              229,
+              101,
+              136,
+              138,
+              14,
+            ],
+          },
+          "locType": "Transaction",
+          "status": "OPEN",
+          "voidInfo": Object {},
+        }
+      }
+    />
+  </React.Fragment>
   <div
     className="separator"
     style={

--- a/src/logion-chain/LogionChainContext.tsx
+++ b/src/logion-chain/LogionChainContext.tsx
@@ -159,7 +159,6 @@ function buildAxiosFactory(authenticatedClient?: LogionClient): AxiosFactory {
 }
 
 const reducer: Reducer<FullLogionChainContextType, Action> = (state: FullLogionChainContextType, action: Action): FullLogionChainContextType => {
-    console.log(action.type)
     switch (action.type) {
         case 'CONNECT_INIT':
             return { ...state, connecting: true };

--- a/src/wallet-user/transaction-protection/LocCreation.tsx
+++ b/src/wallet-user/transaction-protection/LocCreation.tsx
@@ -39,7 +39,8 @@ export default function LocCreation(props: Props) {
             valueFee: {
                 unit: Numbers.NONE,
                 value: "0",
-            }
+            },
+            legalFee: undefined,
         }
     });
     const [ selectedLegalOfficer, setSelectedLegalOfficer ] = useState<LegalOfficerClass | undefined>();
@@ -73,6 +74,7 @@ export default function LocCreation(props: Props) {
                     description: formValues.description,
                     draft: true,
                     template: backendTemplate(selectedTemplateId),
+                    legalFee: formValues.legalFee ? Currency.toCanonicalAmount(new Numbers.PrefixedNumber(formValues.legalFee.value, formValues.legalFee.unit)) : undefined,
                 }) as DraftRequest;
             } else if(locType === "Identity") {
                 draftRequest = await locsState!.requestIdentityLoc({
@@ -101,6 +103,7 @@ export default function LocCreation(props: Props) {
                     draft: true,
                     template: backendTemplate(selectedTemplateId),
                     valueFee: Currency.toCanonicalAmount(new Numbers.PrefixedNumber(formValues.valueFee.value, formValues.valueFee.unit)),
+                    legalFee: formValues.legalFee ? Currency.toCanonicalAmount(new Numbers.PrefixedNumber(formValues.legalFee.value, formValues.legalFee.unit)) : undefined,
                 }) as DraftRequest;
             } else {
                 throw new Error("Unsupported LOC type");

--- a/yarn.lock
+++ b/yarn.lock
@@ -2977,14 +2977,14 @@ __metadata:
   linkType: hard
 
 "@logion/client@npm:^0.30.1-1":
-  version: 0.30.1-1
-  resolution: "@logion/client@npm:0.30.1-1"
+  version: 0.30.1-4
+  resolution: "@logion/client@npm:0.30.1-4"
   dependencies:
-    "@logion/node-api": ^0.20.0
+    "@logion/node-api": ^0.21.0-2
     axios: ^0.27.2
     luxon: ^3.0.1
     mime-db: ^1.52.0
-  checksum: 1e3f5e145d43c982db4f5fcaa135e2ae4bf7da8cdac8b173d8457c1e6b208138716afe61fc2a0c6e90302e9b5b03f67d2d9e85f266d01381b76ff9b60df7588a
+  checksum: e9509a5309d2b2746738b47aec10fae1209a92bffe3a4eeb9fa625c2c6f2cf5b2585426773691e72afdc366963579566a1d0cc038aefb65447ce6b5a426b1a10
   languageName: node
   linkType: hard
 
@@ -3020,9 +3020,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@logion/node-api@npm:^0.20.0":
-  version: 0.20.0
-  resolution: "@logion/node-api@npm:0.20.0"
+"@logion/node-api@npm:^0.21.0-2":
+  version: 0.21.0-2
+  resolution: "@logion/node-api@npm:0.21.0-2"
   dependencies:
     "@polkadot/api": ^10.9.1
     "@polkadot/util": ^12.3.2
@@ -3030,7 +3030,7 @@ __metadata:
     "@types/uuid": ^9.0.2
     fast-sha256: ^1.3.0
     uuid: ^9.0.0
-  checksum: e3d312763b0fc5bc858294477e51ce0424107888d5d632531dbcace622bd3aa87f30c69cd8347afb48d2908531b8934f7477d8e9d90f7cafdb245668bd05aef8
+  checksum: 36c3ebb8a65175654ed57e5e89215d74b24690316210f8b12e38f0abab21a3f0a3e0418cfcd8266606374dcf26210e5789b8ff916b7f568d26d9b6cbc4d76beb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
* Requester may set a custom legal fee for transaction and collection LOCs.
* The field is not visible by default (using a collapse pane).
* Legal fee is now displayed in collection info and (new) transaction info boxes (above items); when default fee is applied, it is displayed.
* The fields in LOC creation dialog have been re-ordered to better follow logical flow (first choose a LLO, then a description, then ...).

logion-network/logion-internal#984