### PR TITLE
Template items default title

### DIFF
--- a/src/legal-officer/transaction-protection/LocRequestAcceptanceAndCreation.test.tsx
+++ b/src/legal-officer/transaction-protection/LocRequestAcceptanceAndCreation.test.tsx
@@ -39,7 +39,7 @@ describe("LocRequestAcceptance", () => {
 
         setupApiMock(api => {
             const submittable = mockSubmittable();
-            api.setup(instance => instance.polkadot.tx.logionLoc.createPolkadotTransactionLoc(It.IsAny(), It.IsAny(), null)).returns(submittable.object());
+            api.setup(instance => instance.polkadot.tx.logionLoc.createPolkadotTransactionLoc(It.IsAny(), It.IsAny(), null, It.IsAny())).returns(submittable.object());
             const fees = new Mock<Fees>();
             api.setup(instance => instance.fees.estimateCreateLoc(It.IsAny())).returnsAsync(fees.object());
         });
@@ -70,7 +70,7 @@ describe("LocRequestAcceptance", () => {
 
         setupApiMock(api => {
             const submittable = mockSubmittable();
-            api.setup(instance => instance.polkadot.tx.logionLoc.createCollectionLoc(It.IsAny(), It.IsAny(), It.IsAny(), It.IsAny(), It.IsAny(), It.IsAny(), null)).returns(submittable.object());
+            api.setup(instance => instance.polkadot.tx.logionLoc.createCollectionLoc(It.IsAny(), It.IsAny(), It.IsAny(), It.IsAny(), It.IsAny(), It.IsAny(), null, It.IsAny())).returns(submittable.object());
             const fees = new Mock<Fees>();
             api.setup(instance => instance.fees.estimateCreateLoc(It.IsAny())).returnsAsync(fees.object());
         });

--- a/src/loc/LocItem.tsx
+++ b/src/loc/LocItem.tsx
@@ -65,6 +65,7 @@ export interface CommonData {
     readonly rejectReason?: string;
     readonly acknowledgedByOwner?: boolean;
     readonly acknowledgedByVerifiedIssuer?: boolean;
+    readonly defaultTitle?: string;
 }
 
 abstract class AbstractLocItem<T> implements CommonData {
@@ -125,6 +126,10 @@ abstract class AbstractLocItem<T> implements CommonData {
         return this.commonData.acknowledgedByVerifiedIssuer;
     }
 
+    get defaultTitle(): string  {
+        return this.commonData.defaultTitle || this.commonData.type;
+    }
+
     isPublishedOrAcknowledged(): boolean {
         return this.commonData.status === "PUBLISHED" || this.commonData.status === "ACKNOWLEDGED"
     }
@@ -163,7 +168,11 @@ export class MetadataItem extends AbstractLocItem<MetadataData> {
     static TYPE: LocItemType = "Data";
     
     override title() {
-        return this.data().name || "-";
+        if (this.hasData()) {
+            return this.data().name || "-";
+        } else {
+            return this.defaultTitle;
+        }
     }
 
     override publish(timestamp: string | null, fees?: Fees, _storageFeePaidBy?: string): MetadataItem {
@@ -181,7 +190,11 @@ export class MetadataItem extends AbstractLocItem<MetadataData> {
 export class FileItem extends AbstractLocItem<FileData> {
 
     override title() {
-        return this.data().nature || "-";
+        if (this.hasData()) {
+            return this.data().nature || "-";
+        } else {
+            return this.defaultTitle
+        }
     }
 
     override publish(timestamp: string | null, fees?: Fees, storageFeePaidBy?: string): FileItem {
@@ -203,7 +216,11 @@ export class FileItem extends AbstractLocItem<FileData> {
 export class LinkItem extends AbstractLocItem<LinkData> {
 
     override title() {
-        return this.data().nature || "-";
+        if (this.hasData()) {
+            return this.data().nature || "-";
+        } else {
+            return this.defaultTitle;
+        }
     }
 
     override publish(timestamp: string | null, fees?: Fees, _storageFeePaidBy?: string): LinkItem {

--- a/src/loc/LocItemFactory.ts
+++ b/src/loc/LocItemFactory.ts
@@ -142,6 +142,7 @@ export function createDocumentTemplateItem(templateItem: LocTemplateDocumentOrLi
             rejectReason: locItem?.rejectReason,
             acknowledgedByOwner: locItem?.acknowledgedByOwner,
             acknowledgedByVerifiedIssuer: locItem?.acknowledgedByVerifiedIssuer,
+            defaultTitle: templateItem.publicDescription,
         },
         locItem ? {
             fileName: locItem.name,
@@ -168,6 +169,7 @@ export function createMetadataTemplateItem(templateItem: LocTemplateMetadataItem
             rejectReason: locItem?.rejectReason,
             acknowledgedByOwner: locItem?.acknowledgedByOwner,
             acknowledgedByVerifiedIssuer: locItem?.acknowledgedByVerifiedIssuer,
+            defaultTitle: templateItem.name,
         },
         locItem ? {
             nameHash: locItem.nameHash,
@@ -196,6 +198,7 @@ export function createLinkTemplateItem(
             rejectReason: locItem?.rejectReason,
             acknowledgedByOwner: locItem?.acknowledgedByOwner,
             acknowledgedByVerifiedIssuer: locItem?.acknowledgedByVerifiedIssuer,
+            defaultTitle: templateItem.publicDescription,
         },
         (linkData && locItem) ? {
             nature: templateItem.publicDescription,

--- a/src/loc/LocTemplateItems.tsx
+++ b/src/loc/LocTemplateItems.tsx
@@ -21,9 +21,6 @@ import {
     useDeleteMetadataCallback,
     useRequestReviewCallback,
     canAcknowledge,
-    MetadataData,
-    FileData,
-    LinkData,
     LinkItem,
     FileItem,
     MetadataItem
@@ -152,19 +149,19 @@ export default function LocTemplateItems(props: Props) {
                 buttons.push(<LocPublicDataButton
                     key={++key}
                     text="Set"
-                    dataName={ item.hasData() ? item.as<MetadataData>().name : undefined }
+                    dataName={ item.title() }
                 />);
             } else if(item.type === "Document") {
                 buttons.push(<LocPrivateFileButton
                     key={++key}
                     text="Set"
-                    nature={ item.hasData() ? item.as<FileData>().nature : undefined }
+                    nature={ item.title() }
                 />);
             } else if(item.type === "Linked LOC") {
                 buttons.push(<LocLinkButton
                     key={++key}
                     text="Set"
-                    nature={ item.hasData() ? item.as<LinkData>().nature : undefined }
+                    nature={ item.title() }
                 />);
             }
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2977,14 +2977,14 @@ __metadata:
   linkType: hard
 
 "@logion/client@npm:^0.31.0-1":
-  version: 0.31.0-2
-  resolution: "@logion/client@npm:0.31.0-2"
+  version: 0.31.0-3
+  resolution: "@logion/client@npm:0.31.0-3"
   dependencies:
-    "@logion/node-api": ^0.22.0-2
+    "@logion/node-api": ^0.22.0-3
     axios: ^0.27.2
     luxon: ^3.0.1
     mime-db: ^1.52.0
-  checksum: 60225ff2e29076813c12052ad9714a0641ea9aeed76423b560a7320bdf62a3d49385f879d2424fc4f09c629776f44d7d2df7098bd3352e02d7eb2edeb55c124e
+  checksum: 7298094d64d4deb31bfb30afe0a7b9808a2bbde7c1ae76dd7554e5f512a32dc78060e78a3903e889f64b7c333cb228fddb4d75781bbdd3944d561c23ef8eef0a
   languageName: node
   linkType: hard
 
@@ -3020,9 +3020,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@logion/node-api@npm:^0.22.0-2":
-  version: 0.22.0-2
-  resolution: "@logion/node-api@npm:0.22.0-2"
+"@logion/node-api@npm:^0.22.0-3":
+  version: 0.22.0-3
+  resolution: "@logion/node-api@npm:0.22.0-3"
   dependencies:
     "@polkadot/api": ^10.9.1
     "@polkadot/util": ^12.3.2
@@ -3030,7 +3030,7 @@ __metadata:
     "@types/uuid": ^9.0.2
     fast-sha256: ^1.3.0
     uuid: ^9.0.0
-  checksum: f2ae4bf3facc44c0b35db8098ae1e1bf31d7e4824cd014080a23a7036e9a079e9144710adefd597c95b4381a74ce368a090b72f0ea81f96e9506f863fc57a03c
+  checksum: 94f67d24af8f0b84be029c05af5df441b56d793c21fc55148ff12eafe94e84ba73530f94e34e9c1127cda2be6166573bb97f09ccf7d9311832eda578ffa5da33
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
* Add the attribute `defaultTitle` to LocItems. Intended use is to display a meaningful title when `data` is not available yet - typically when handling items from a template.
* inject `node-api` and `client` matching latest node.

logion-network/logion-internal#997
