### PR TITLE
Enable/disable restricted delivery toggle when needed

### DIFF
--- a/src/components/toggle/Checkbox.tsx
+++ b/src/components/toggle/Checkbox.tsx
@@ -19,6 +19,6 @@ export default function Checkbox(props: Props) {
         props.disabled ? "disabled" : undefined,
     );
     return (
-        <div role="checkbox" aria-checked={ props.checked } className={ className } onClick={() => props.setChecked && props.setChecked(!props.checked)}></div>
+        <div role="checkbox" aria-checked={ props.checked } className={ className } onClick={() => !props.disabled && props.setChecked && props.setChecked(!props.checked)}></div>
     );
 }

--- a/src/loc/RestricedDeliveryCell.tsx
+++ b/src/loc/RestricedDeliveryCell.tsx
@@ -49,6 +49,8 @@ export default function RestrictedDeliveryCell(props: Props) {
         return file?.restrictedDelivery || false;
     }, [ props.hash, loc ]);
 
+    const alwaysDisabled = useMemo(() => loc?.status !== "OPEN" && loc?.status !== "CLOSED", [ loc ]);
+
     return (
         <Cell content={
             <div className="RestrictedDeliveryCell checkbox-container">
@@ -66,7 +68,7 @@ export default function RestrictedDeliveryCell(props: Props) {
                             skin="Toggle black"
                             checked={checked}
                             setChecked={value => confirmCallback(value)}
-                            disabled={disabled}
+                            disabled={ alwaysDisabled || disabled }
                         />
                     </div>
                 </OverlayTrigger>

--- a/src/loc/RestrictedDeliveryCell.test.tsx
+++ b/src/loc/RestrictedDeliveryCell.test.tsx
@@ -26,7 +26,8 @@ describe("RestrictedDeliveryCell", () => {
                 published: false,
                 restrictedDelivery: false,
                 submitter: DEFAULT_ADDRESS,
-            }]
+            }],
+            status: "OPEN",
         } as unknown as LocData);
         setLocState(openLoc);
         const result = shallowRender(<RestrictedDeliveryCell hash={hash}/>);


### PR DESCRIPTION
* The toggle in "Restricted Delivery" column is now disabled if the LOC is not open or closed (the only statuses for which the toggle makes sense).

logion-network/logion-internal#1027