### PR TITLE
Acknowledgment of items

### DIFF
--- a/src/ExtrinsicSubmissionStateView.tsx
+++ b/src/ExtrinsicSubmissionStateView.tsx
@@ -1,0 +1,22 @@
+import { useLogionChain } from './logion-chain/LogionChainContext';
+import ExtrinsicSubmissionResult from './ExtrinsicSubmissionResult';
+
+export interface Props {
+    successMessage?: string;
+    slim?: boolean;
+}
+
+export default function ExtrinsicSubmissionStateView(props: Props) {
+    const { extrinsicSubmissionState } = useLogionChain();
+
+    if(extrinsicSubmissionState.submitted) {
+        return (<ExtrinsicSubmissionResult
+            error={ extrinsicSubmissionState.error }
+            result={ extrinsicSubmissionState.result }
+            successMessage={ props.successMessage }
+            slim={ props.slim }
+        />);
+    } else {
+        return null;
+    }
+}

--- a/src/logion-chain/index.tsx
+++ b/src/logion-chain/index.tsx
@@ -2,6 +2,7 @@ import {
     useLogionChain,
     LogionChainContextProvider,
     AxiosFactory,
+    CallCallback,
 } from './LogionChainContext';
 
 export {
@@ -10,4 +11,5 @@ export {
 };
 export type {
     AxiosFactory,
+    CallCallback,
 };


### PR DESCRIPTION
* The fix is taken as an opportunity to refactor code and stop using effects to handle extrinsic submission.
* `ExtrinsicSubmissionStateView` is introduced to simplify display of `LogionChainContext`'s `extrinsicSubmissionState`.
* Calls are submitted directly by components using context's `submitCall(call)`.
* Submission state is explicitly cleared by calling `clearSubmissionState()`.

logion-network/logion-internal#1078