### PR TITLE
Add Tokens record certificate.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dependencies": {
         "@craco/craco": "^7.1.0",
         "@creativecommons/cc-assets": "^0.1.0",
-        "@logion/client": "^0.40.1",
+        "@logion/client": "^0.41.0-1",
         "@logion/client-browser": "^0.3.4",
         "@logion/crossmint": "^0.1.32",
         "@logion/extension": "^0.7.6",

--- a/src/PublicPaths.tsx
+++ b/src/PublicPaths.tsx
@@ -2,25 +2,30 @@ import { UUID, Hash } from "@logion/node-api";
 
 export const PUBLIC_PATH = "/public";
 export const CERTIFICATE_RELATIVE_PATH = "/certificate/:locId";
-export const CERTIFICATE_PATH = PUBLIC_PATH + CERTIFICATE_RELATIVE_PATH;
+const CERTIFICATE_PATH = PUBLIC_PATH + CERTIFICATE_RELATIVE_PATH;
 
-const COLLECTION_ITEM_CERTIFICATE_PATH = CERTIFICATE_PATH + "/:collectionItemId";
+export const COLLECTION_ITEM_CERTIFICATE_RELATIVE_PATH = ":collectionItemId";
+const COLLECTION_ITEM_CERTIFICATE_PATH = CERTIFICATE_PATH + "/" + COLLECTION_ITEM_CERTIFICATE_RELATIVE_PATH;
 
-function certificatePath(locId: UUID, collectionItemId?: Hash): string {
+export const TOKENS_RECORD_CERTIFICATE_RELATIVE_PATH = "record/:tokensRecordId";
+const TOKENS_RECORD_CERTIFICATE_PATH = CERTIFICATE_PATH + "/" + TOKENS_RECORD_CERTIFICATE_RELATIVE_PATH;
+
+function certificatePath(locId: UUID, params: { collectionItemId?: Hash, tokensRecordId?: Hash }): string {
+    const { collectionItemId, tokensRecordId } = params;
     if (collectionItemId) {
         return COLLECTION_ITEM_CERTIFICATE_PATH
             .replace(":locId", locId.toDecimalString())
             .replace(":collectionItemId", collectionItemId.toHex())
+    } else if (tokensRecordId) {
+        return TOKENS_RECORD_CERTIFICATE_PATH
+            .replace(":locId", locId.toDecimalString())
+            .replace(":tokensRecordId", tokensRecordId.toHex())
     } else {
         return CERTIFICATE_PATH.replace(":locId", locId.toDecimalString())
     }
 }
 
-export function fullCertificateUrl(locId: UUID, noRedirect?: boolean, redirected?: boolean): string {
-    return fullCollectionItemCertificate(locId, undefined, noRedirect, redirected)
-}
-
-export function fullCollectionItemCertificate(locId: UUID, collectionItemId?: Hash, noRedirect?: boolean, redirected?: boolean): string {
+function redirectQuery(noRedirect?: boolean, redirected?: boolean): string {
     const queries = [];
     if (noRedirect) {
         queries.push("noredirect=1");
@@ -28,8 +33,19 @@ export function fullCollectionItemCertificate(locId: UUID, collectionItemId?: Ha
     if (redirected) {
         queries.push("redirected=1");
     }
-    const query = queries.length === 0 ? "" : "?" + queries.join('&');
-    return `${ getBaseUrl() }${ certificatePath(locId, collectionItemId) }${ query }`;
+    return queries.length === 0 ? "" : "?" + queries.join('&');
+}
+
+export function fullCertificateUrl(locId: UUID, noRedirect?: boolean, redirected?: boolean): string {
+    return `${ getBaseUrl() }${ certificatePath(locId, {}) }${ redirectQuery(noRedirect, redirected) }`;
+}
+
+export function fullCollectionItemCertificate(locId: UUID, collectionItemId: Hash, noRedirect?: boolean, redirected?: boolean): string {
+    return `${ getBaseUrl() }${ certificatePath(locId, { collectionItemId }) }${ redirectQuery(noRedirect, redirected) }`;
+}
+
+export function fullTokensRecordsCertificate(locId: UUID, recordId: Hash, noRedirect?: boolean, redirected?: boolean): string {
+    return `${ getBaseUrl() }${ certificatePath(locId, { tokensRecordId: recordId }) }${ redirectQuery(noRedirect, redirected) }`;
 }
 
 export function getBaseUrl(): string {

--- a/src/PublicRouter.tsx
+++ b/src/PublicRouter.tsx
@@ -1,13 +1,18 @@
 import { Routes, Route } from "react-router-dom";
 import Certificate from "./certificate/Certificate";
-import { CERTIFICATE_RELATIVE_PATH } from "./PublicPaths";
+import {
+    CERTIFICATE_RELATIVE_PATH,
+    COLLECTION_ITEM_CERTIFICATE_RELATIVE_PATH,
+    TOKENS_RECORD_CERTIFICATE_RELATIVE_PATH
+} from "./PublicPaths";
 
 export default function PublicRouter() {
     return (
         <Routes>
             <Route path={ CERTIFICATE_RELATIVE_PATH } >
                 <Route path="" element={ <Certificate /> } />
-                <Route path=":collectionItemId" element={ <Certificate /> } />
+                <Route path={ COLLECTION_ITEM_CERTIFICATE_RELATIVE_PATH } element={ <Certificate /> } />
+                <Route path={ TOKENS_RECORD_CERTIFICATE_RELATIVE_PATH } element={ <Certificate /> } />
             </Route>
         </Routes>
     )

--- a/src/certificate/Certificate.test.tsx
+++ b/src/certificate/Certificate.test.tsx
@@ -182,7 +182,7 @@ function mockClient(loc: PublicLoc, item?: CollectionItem, tokensRecord?: Client
                     throw Error("LOC not found")
                 }
             },
-            getTokensRecords: () => Promise.resolve([]),
+            getTokensRecords: () => Promise.resolve( tokensRecord ? [ tokensRecord ] : []),
             getTokensRecord: () => Promise.resolve(tokensRecord),
         },
     } as unknown as LogionClient;

--- a/src/certificate/Certificate.test.tsx
+++ b/src/certificate/Certificate.test.tsx
@@ -1,4 +1,4 @@
-import { LogionClient, PublicLoc, LocData, CollectionItem, HashString } from '@logion/client';
+import { LogionClient, PublicLoc, LocData, CollectionItem, HashString, TokensRecord } from '@logion/client';
 import { UUID, Hash } from '@logion/node-api';
 import { render, screen, waitFor } from "@testing-library/react";
 import { act } from 'react-test-renderer';
@@ -10,6 +10,7 @@ import Certificate from './Certificate';
 import { setClientMock } from 'src/logion-chain/__mocks__/LogionChainMock';
 import { PATRICK } from 'src/common/TestData';
 import { URLSearchParams } from 'url';
+import { ClientTokensRecord } from "@logion/client/dist/LocClient";
 
 jest.mock("react-router");
 jest.mock("react-router-dom");
@@ -47,6 +48,24 @@ describe("Certificate", () => {
         expect(() => screen.getByText("Legal Officer Case")).toThrow();
     })
 
+    it("renders TOKENS RECORD not found", async () => {
+        const locId = UUID.fromDecimalStringOrThrow("95306891657235687884416897796814545554");
+        const loc = mockPublicLoc(locId);
+
+        const client = mockClient(loc);
+        setClientMock(client);
+
+        const nonExistentRecord = Hash.of("some-non-existent-record")
+        setParams({locId: locId.toString(), tokensRecordId: nonExistentRecord.toHex()});
+        setSearchParams(mockEmptySearchParams());
+
+        render(<Certificate/>);
+
+        await waitFor(() => expect(screen.getByText("TOKENS RECORD NOT FOUND")).toBeVisible());
+        expect(screen.getByText(nonExistentRecord.toHex())).toBeVisible();
+        expect(() => screen.getByText("Legal Officer Case")).toThrow();
+    })
+
     it("renders found LOC", async () => {
         const locId = UUID.fromDecimalStringOrThrow("95306891657235687884416897796814545554");
         const loc = mockPublicLoc(locId);
@@ -61,6 +80,26 @@ describe("Certificate", () => {
 
         await waitFor(() => expect(screen.getByText("Legal Officer Case")).toBeVisible());
         expect(screen.getByRole("button", { name: "Check a document" })).toBeVisible();
+    })
+
+    it("renders found TOKENS RECORD", async () => {
+        const locId = UUID.fromDecimalStringOrThrow("95306891657235687884416897796814545554");
+        const loc = mockPublicLoc(locId);
+        const tokensRecord = mockTokensRecord();
+        const client = mockClient(loc, undefined, tokensRecord);
+        setClientMock(client);
+
+        setParams({ locId: locId.toString(), tokensRecordId: tokensRecord.id.toHex() });
+        setSearchParams(mockEmptySearchParams());
+
+        render(<Certificate/>);
+
+        await waitFor(() => expect(screen.getByText("Legal Officer Case")).toBeVisible());
+        expect(screen.getByText("Tokens record")).toBeVisible();
+        expect(screen.getByText(mockTRCellContent(tokensRecord.issuer))).toBeVisible();
+        expect(screen.getByText(mockTRCellContent(tokensRecord.description.validValue()))).toBeVisible();
+        expect(screen.getByText(mockTRCellContent(tokensRecord.files[0].contentType.validValue()))).toBeVisible();
+        expect(screen.getByText(tokensRecord.files[0].name.validValue())).toBeVisible();
     })
 
     it("renders item with restricted delivery", async () => {
@@ -80,6 +119,10 @@ describe("Certificate", () => {
         expect(checkAssetButton).toBe(null);
     })
 })
+
+function mockTRCellContent(content: string): string {
+    return `: ${ content }`
+}
 
 function mockPublicLoc(locId: UUID): PublicLoc {
     return {
@@ -128,7 +171,7 @@ function mockCollectionItem(locId: UUID, itemId: Hash, restrictedDelivery: boole
     } as unknown as CollectionItem;
 }
 
-function mockClient(loc: PublicLoc, item?: CollectionItem): LogionClient {
+function mockClient(loc: PublicLoc, item?: CollectionItem, tokensRecord?: ClientTokensRecord): LogionClient {
     const client = {
         legalOfficers: [ PATRICK ],
         public: {
@@ -140,6 +183,7 @@ function mockClient(loc: PublicLoc, item?: CollectionItem): LogionClient {
                 }
             },
             getTokensRecords: () => Promise.resolve([]),
+            getTokensRecord: () => Promise.resolve(tokensRecord),
         },
     } as unknown as LogionClient;
 
@@ -155,4 +199,21 @@ function mockClient(loc: PublicLoc, item?: CollectionItem): LogionClient {
     }
 
     return client;
+}
+
+function mockTokensRecord(): ClientTokensRecord {
+    return {
+        id: Hash.of("record-id"),
+        description: HashString.fromValue("Record Description"),
+        addedOn: "2022-08-23T07:27:46.128Z",
+        issuer: "record-issuer",
+        files: [ {
+            name: HashString.fromValue("record-file-name.txt"),
+            hash: Hash.of("record-file-content"),
+            size: 10n,
+            uploaded: true,
+            contentType: HashString.fromValue("text/plain")
+        } ]
+
+    }
 }

--- a/src/certificate/Certificate.tsx
+++ b/src/certificate/Certificate.tsx
@@ -51,6 +51,7 @@ export default function Certificate() {
 
     const locIdParam = useParams<"locId">().locId!;
     const collectionItemIdParam = useParams<"collectionItemId">().collectionItemId;
+    const tokensRecordIdParam = useParams<"tokensRecordId">().tokensRecordId;
     const [ searchParams ] = useSearchParams();
     const locId: UUID = useMemo(() => UUID.fromAnyString(locIdParam)!, [ locIdParam ]);
     const { client } = useLogionChain();
@@ -122,6 +123,21 @@ export default function Certificate() {
         }
     }, [ client, locId, tokensRecords, tokenForDownload ]);
 
+    useEffect(() => {
+        if (client && tokensRecordIdParam && tokensRecords === null) {
+            console.log("Getting Tokens records...")
+            client.public.getTokensRecord({ locId, recordId: Hash.fromHex(tokensRecordIdParam)})
+                .then(tokensRecord => {
+                    console.log(tokensRecord);
+                    if (tokensRecord) {
+                        setTokensRecords([ tokensRecord ]);
+                    } else {
+                        setTokensRecords([ ]);
+                    }
+                })
+        }
+    }, [ client, locId, tokensRecords, tokensRecordIdParam ]);
+
     if (!client || loc === undefined) {
         return (
             <div className="Certificate">
@@ -150,6 +166,20 @@ export default function Certificate() {
                         <CertificateCell md={ 4 } label="LOC ID">{ locId.toDecimalString() }</CertificateCell>
                         <CertificateCell md={ 4 }
                                          label="COLLECTION ITEM NOT FOUND">{ collectionItemIdParam }</CertificateCell>
+                    </Row>
+                </Container>
+            </div>
+        )
+    }
+
+    if (tokensRecordIdParam && tokensRecords !== null && tokensRecords.length === 0) {
+        return (
+            <div className="CertificateBox">
+                <Container>
+                    <Row>
+                        <CertificateCell md={ 4 } label="LOC ID">{ locId.toDecimalString() }</CertificateCell>
+                        <CertificateCell md={ 4 }
+                                         label="TOKENS RECORD NOT FOUND">{ tokensRecordIdParam }</CertificateCell>
                     </Row>
                 </Container>
             </div>
@@ -305,7 +335,7 @@ export default function Certificate() {
                             />
                         </Col>
                         <Col md={ 7 }>
-                            <IntroductionText loc={ loc } tokenGated={ true } />
+                            <IntroductionText loc={ loc } type="TokenGated" />
                         </Col>
                     </Row>
                 }
@@ -313,7 +343,7 @@ export default function Certificate() {
                     <Row>
                         <Col md={ 2 }/>
                         <Col md={ 8 }>
-                            <IntroductionText loc={ loc } tokenGated={ false } />
+                            <IntroductionText loc={ loc } type={ tokensRecordIdParam ? "TokensRecord" : "Regular" } />
                         </Col>
                     </Row>
                 }
@@ -365,13 +395,13 @@ export default function Certificate() {
                         tokenForDownload={ tokenForDownload }
                     />
                 }
-                { collectionItem !== null && tokenForDownload !== undefined &&
+                { tokensRecords !== null &&
                     <TokensRecords
                         locId={ locId }
                         owner={ legalOfficer.address }
                         collectionItem={ collectionItem! }
                         tokenForDownload={ tokenForDownload }
-                        tokensRecords={ tokensRecords || [] }
+                        tokensRecords={ tokensRecords }
                         checkResult={ checkResult }
                     />
                 }

--- a/src/certificate/Certificate.tsx
+++ b/src/certificate/Certificate.tsx
@@ -125,10 +125,8 @@ export default function Certificate() {
 
     useEffect(() => {
         if (client && tokensRecordIdParam && tokensRecords === null) {
-            console.log("Getting Tokens records...")
             client.public.getTokensRecord({ locId, recordId: Hash.fromHex(tokensRecordIdParam)})
                 .then(tokensRecord => {
-                    console.log(tokensRecord);
                     if (tokensRecord) {
                         setTokensRecords([ tokensRecord ]);
                     } else {

--- a/src/certificate/IntroductionText.tsx
+++ b/src/certificate/IntroductionText.tsx
@@ -1,16 +1,17 @@
 import { PublicLoc } from "@logion/client";
 import QrCode from "src/components/qrcode/QrCode";
-import { fullCertificateUrl } from "src/PublicPaths";
+
+export type IntroductionType = 'Regular' | 'TokenGated' | 'TokensRecord';
 
 export interface Props {
     loc: PublicLoc
-    tokenGated: boolean
+    type: IntroductionType
 }
 
 const QR_CODE_WIDTH = "150px";
 
 export default function IntroductionText(props: Props) {
-    const { loc, tokenGated } = props
+    const { loc, type } = props
 
     if (loc.isLogionIdentityLoc()) {
         return <div className="description">
@@ -27,10 +28,10 @@ export default function IntroductionText(props: Props) {
             <p>All timestamps are displayed using Universal Time Coordinated (UTC).</p>
             <p>A PDF or print of this certificate is NOT valid. This Certificate is only valid when generated online by accessing its URL or through the following QR CODE:</p>
             <div className="qrcode-container">
-                <QrCode data={ fullCertificateUrl(loc.data.id) } width={ QR_CODE_WIDTH }/>
+                <QrCode data={ window.location.href } width={ QR_CODE_WIDTH }/>
             </div>
         </div>
-    } else if (loc.data.locType === 'Collection' && !tokenGated) {
+    } else if (loc.data.locType === 'Collection' && type === "Regular") {
         return <div className="description">
             <p>This Logion Legal Officer Case (LOC) certificate is delivered for a <strong>COLLECTION</strong> and its
                 related <strong>COLLECTION ITEMS</strong>. Thus, the collection item identified below benefits from the
@@ -41,10 +42,10 @@ export default function IntroductionText(props: Props) {
             <p>All timestamps are displayed using Universal Time Coordinated (UTC).</p>
             <p>A PDF or print of this certificate is NOT valid. This Certificate is only valid when generated online by accessing its URL or through the following QR CODE:</p>
             <div className="qrcode-container">
-                <QrCode data={ fullCertificateUrl(loc.data.id) } width={ QR_CODE_WIDTH }/>
+                <QrCode data={ window.location.href } width={ QR_CODE_WIDTH }/>
             </div>
         </div>
-    } else if (loc.data.locType === 'Collection' && tokenGated) {
+    } else if (loc.data.locType === 'Collection' && type === "TokenGated") {
         return <div className="description">
             <p>This Logion Legal Officer Case (LOC) certificate is delivered for a <strong>COLLECTION ITEM</strong> and
                 its related <strong>COLLECTION</strong>. Thus, the collection item identified below benefits from the
@@ -55,7 +56,21 @@ export default function IntroductionText(props: Props) {
             <p>All timestamps are displayed using Universal Time Coordinated (UTC).</p>
             <p>A PDF or print of this certificate is NOT valid. This Certificate is only valid when generated online by accessing its URL or through the following QR CODE:</p>
             <div className="qrcode-container">
-                <QrCode data={ fullCertificateUrl(loc.data.id) } width={ QR_CODE_WIDTH }/>
+                <QrCode data={ window.location.href } width={ QR_CODE_WIDTH }/>
+            </div>
+        </div>
+    } else if (loc.data.locType === 'Collection' && type === "TokensRecord") {
+        return <div className="description">
+            <p>This Logion Legal Officer Case (LOC) certificate is delivered for a <strong>TOKENS RECORD</strong> and
+                its related <strong>COLLECTION</strong>. Thus, the tokens record identified below benefits from the
+                scope of this LOC.</p>
+            <p>This Certificate constitutes proof that a Logion Legal Officer, owner of that LOC and mentioned on this
+                document, executed a verification process according to his/her professional standards at the requester
+                demand with regards to data and document(s) listed below.</p>
+            <p>All timestamps are displayed using Universal Time Coordinated (UTC).</p>
+            <p>A PDF or print of this certificate is NOT valid. This Certificate is only valid when generated online by accessing its URL or through the following QR CODE:</p>
+            <div className="qrcode-container">
+                <QrCode data={ window.location.href } width={ QR_CODE_WIDTH }/>
             </div>
         </div>
     } else {
@@ -67,7 +82,7 @@ export default function IntroductionText(props: Props) {
             <p>All timestamps are displayed using Universal Time Coordinated (UTC).</p>
             <p>A PDF or print of this certificate is NOT valid. This Certificate is only valid when generated online by accessing its URL or through the following QR CODE:</p>
             <div className="qrcode-container">
-                <QrCode data={ fullCertificateUrl(loc.data.id) } width={ QR_CODE_WIDTH }/>
+                <QrCode data={ window.location.href } width={ QR_CODE_WIDTH }/>
             </div>
         </div>
     }

--- a/src/certificate/TokensRecords.tsx
+++ b/src/certificate/TokensRecords.tsx
@@ -12,7 +12,7 @@ export interface TokensRecordsProps {
     locId: UUID,
     owner: string,
     collectionItem: CollectionItem,
-    tokenForDownload: Token,
+    tokenForDownload: Token | undefined,
     tokensRecords: TokensRecord[];
     checkResult?: CheckHashResult;
 }
@@ -23,13 +23,18 @@ export default function TokensRecords(props: TokensRecordsProps) {
     if (tokensRecords.length === 0) {
         return null;
     }
+    const title = tokensRecords.length === 1 ?
+        "Tokens record" :
+        "Tokens records";
+    const introduction = tokensRecords.length === 1 ?
+        "The following Tokens Record is signed by the issuer." :
+        "The following Tokens Records, shared with all the owners of tokens declared in this LOC, are signed by issuers."
     return (
         <div className="TokensRecords">
             <Row>
                 <Col>
-                    <h2><MenuIcon icon={ { id: "records_polka" } } height="40px" width="70px" /> Tokens record(s)</h2>
-                    <p>The following Tokens Records, shared with all the owners of tokens declared in this LOC, are
-                        signed by logion Verified Issuers.</p>
+                    <h2><MenuIcon icon={ { id: "records_polka" } } height="40px" width="70px" /> { title }</h2>
+                    <p>{ introduction }</p>
                 </Col>
             </Row>
             { tokensRecords.map((tokensRecord, index) => (

--- a/src/loc/ImportItemDetails.tsx
+++ b/src/loc/ImportItemDetails.tsx
@@ -97,7 +97,7 @@ export default function ImportItemDetails(props: { locId: UUID, item: Item }) {
                         <p>Certificate QR code (only valid after successful import):</p>
                         <p className="qr">
                             <QrCode
-                                data={ fullCollectionItemCertificate(props.locId, props.item.id) }
+                                data={ fullCollectionItemCertificate(props.locId, props.item.id!) }
                                 width="200px"
                             />
                         </p>
@@ -106,7 +106,7 @@ export default function ImportItemDetails(props: { locId: UUID, item: Item }) {
             </Row>
             <div className="item-certificate">
                 <p>Certificate URL (only valid after successful import):</p>
-                <p className="url">{ fullCollectionItemCertificate(props.locId, props.item.id) } <CopyPasteButton value={ fullCollectionItemCertificate(props.locId, props.item.id) } /></p>
+                <p className="url">{ fullCollectionItemCertificate(props.locId, props.item.id!) } <CopyPasteButton value={ fullCollectionItemCertificate(props.locId, props.item.id!) } /></p>
             </div>
         </div>
     );

--- a/src/loc/record/TokensRecordTable.css
+++ b/src/loc/record/TokensRecordTable.css
@@ -1,0 +1,3 @@
+.TokensRecordTable .ViewFileButton {
+    height: 40px;
+}

--- a/src/loc/record/TokensRecordTable.tsx
+++ b/src/loc/record/TokensRecordTable.tsx
@@ -13,6 +13,9 @@ import { ContributionMode } from "../types";
 import { tokensRecordDocumentClaimHistoryPath as requesterTokensRecordDocumentClaimHistoryPath, issuerTokensRecordDocumentClaimHistoryPath } from "src/wallet-user/UserRouter";
 import { useLogionChain } from "src/logion-chain";
 import { FileItem } from "../LocItem";
+import ViewCertificateButton from "../ViewCertificateButton";
+import { fullTokensRecordsCertificate } from "../../PublicPaths";
+import "./TokensRecordTable.css";
 
 export interface Props {
     records: TokensRecord[];
@@ -34,7 +37,7 @@ export default function TokensRecordTable(props: Props) {
         return null;
     }
 
-    return (
+    return ( <div className="TokensRecordTable">
         <PagedTable
             columns={[
                 {
@@ -47,7 +50,7 @@ export default function TokensRecordTable(props: Props) {
                     renderDetails: record => <LocPrivateFileDetails
                         item={new FileItem(
                             {
-                                
+
                                 newItem: false,
                                 status: "PUBLISHED",
                                 submitter: api.queries.getValidAccountId(record.issuer, "Polkadot"),
@@ -98,7 +101,16 @@ export default function TokensRecordTable(props: Props) {
                             }) }
                         />
                     } />,
-                    align: "left",
+                    align: "center",
+                    width: "100px",
+                },
+                {
+                    header: "Certificate",
+                    render: record => <Cell content={
+                        <ViewCertificateButton url={ fullTokensRecordsCertificate(loc.id, record.id) } />
+                    } />,
+                    align: "center",
+                    width: "100px",
                 }
             ]}
             currentPage={ currentPage }
@@ -106,7 +118,7 @@ export default function TokensRecordTable(props: Props) {
             fullSize={ records.length }
             renderEmpty={ () => <EmptyTableMessage>No records to display</EmptyTableMessage> }
         />
-    );
+    </div>);
 }
 
 function documentClaimHistory(viewer: Viewer, loc: LocData, record: TokensRecord, contributionMode?: ContributionMode): string {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4297,15 +4297,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@logion/client@npm:^0.40.1":
-  version: 0.40.1
-  resolution: "@logion/client@npm:0.40.1"
+"@logion/client@npm:^0.41.0-1":
+  version: 0.41.0-1
+  resolution: "@logion/client@npm:0.41.0-1"
   dependencies:
     "@logion/node-api": ^0.28.2
     axios: ^0.27.2
     luxon: ^3.0.1
     mime-db: ^1.52.0
-  checksum: 9d66e4946afc9d88ba02b9d3cbe1a94332e20ff42935169cb5e73172b71ae22a919ef63e2a7f1645fb3fcb33b6e9785d029608f6b154d7d08315405dd6a02ae6
+  checksum: 5635a66586d826b6abb01b31eab12a4c5ec0afd58f045a3de36812c5365f692da1dd6b5b1952206443a6d99aac1347fab96e24ba8de6bb94a94bf0038c0064a8
   languageName: node
   linkType: hard
 
@@ -14102,7 +14102,7 @@ __metadata:
     "@babel/preset-typescript": ^7.23.3
     "@craco/craco": ^7.1.0
     "@creativecommons/cc-assets": ^0.1.0
-    "@logion/client": ^0.40.1
+    "@logion/client": ^0.41.0-1
     "@logion/client-browser": ^0.3.4
     "@logion/crossmint": ^0.1.32
     "@logion/extension": ^0.7.6


### PR DESCRIPTION
* Tokens record has now its dedicated certificate, accessible via [https://certificate.logion.network/public/certificate/`{locId}`/record/`{tokensRecordId}`](https://certificate.logion.network/public/certificate/{locId}/record/{tokensRecordId}).
* Fix: QR code is now correct for every kind of certificate.

Makes use of https://github.com/logion-network/logion-api/commit/ac9a7a8e115031cdcae50e386b72688b53a1e890

logion-network/logion-internal#1154