### PR TITLE
Improve Tokens Records table

### DIFF
--- a/src/certificate/TokensRecords.tsx
+++ b/src/certificate/TokensRecords.tsx
@@ -26,15 +26,15 @@ export default function TokensRecords(props: TokensRecordsProps) {
     const title = tokensRecords.length === 1 ?
         "Tokens record" :
         "Tokens records";
-    const introduction = tokensRecords.length === 1 ?
-        "The following Tokens Record is signed by the issuer." :
-        "The following Tokens Records, shared with all the owners of tokens declared in this LOC, are signed by issuers."
     return (
         <div className="TokensRecords">
             <Row>
                 <Col>
                     <h2><MenuIcon icon={ { id: "records_polka" } } height="40px" width="70px" /> { title }</h2>
-                    <p>{ introduction }</p>
+                    { tokensRecords.length > 1 &&
+                        <p>The following Tokens Records, shared with all the owners of tokens declared in this LOC, are
+                            signed by issuers.</p>
+                    }
                 </Col>
             </Row>
             { tokensRecords.map((tokensRecord, index) => (

--- a/src/loc/record/TokensRecordFiles.css
+++ b/src/loc/record/TokensRecordFiles.css
@@ -1,0 +1,27 @@
+.TokensRecordFiles {
+    padding: 10px 10px 0 10px;
+    width: 100%;
+}
+
+.TokensRecordFiles .value {
+    font-weight: lighter;
+}
+
+.TokensRecordFiles .TokensRecordFileAttribute {
+    margin-bottom: 0 !important;
+}
+
+.TokensRecordFiles .TokensRecordFile .ButtonGroup {
+    margin-top: 18px;
+    position: relative;
+}
+
+.TokensRecordFiles .TokensRecordFile .btn-group {
+    position: absolute;
+    right: 5px;
+}
+
+.TokensRecordFiles .TokensRecordFile .ButtonGroup .Button {
+    min-width: 58px;
+    margin-left: 5px;
+}

--- a/src/loc/record/TokensRecordFiles.tsx
+++ b/src/loc/record/TokensRecordFiles.tsx
@@ -1,0 +1,98 @@
+import { TokensRecord, LocData, UploadableItemFile } from "@logion/client";
+import { ContributionMode } from "../types";
+import { Viewer, useCommonContext } from "../../common/CommonContext";
+import { tokensRecordDocumentClaimHistoryPath } from "../../legal-officer/LegalOfficerPaths";
+import {
+    tokensRecordDocumentClaimHistoryPath as requesterTokensRecordDocumentClaimHistoryPath,
+    issuerTokensRecordDocumentClaimHistoryPath
+} from "../../wallet-user/UserRouter";
+import { useLocContext } from "../LocContext";
+import ViewFileButton from "../../common/ViewFileButton";
+import { getTokensRecordFileSource } from "../FileModel";
+import Button from "../../common/Button";
+import Icon from "../../common/Icon";
+import { useNavigate } from "react-router-dom";
+import ButtonGroup from "../../common/ButtonGroup";
+import Col from "react-bootstrap/Col";
+import { Row } from "../../common/Grid";
+
+export interface Props {
+    record: TokensRecord;
+    contributionMode?: ContributionMode;
+}
+
+export default function TokensRecordFiles(props: Props) {
+
+    const { record } = props;
+    const { loc } = useLocContext();
+
+    if (!loc) {
+        return null;
+    }
+
+    return (<div className="TokensRecordFiles">
+        { record.files.map(file => (
+            <TokensRecordFileCell { ...props } loc={ loc } file={ file } />
+        )) }
+    </div>)
+}
+
+function TokensRecordFileCell(props: Props & { loc: LocData, file: UploadableItemFile }) {
+    const { loc, record, file, contributionMode } = props;
+    const { viewer } = useCommonContext();
+    const navigate = useNavigate();
+
+    return (
+        <Row className="TokensRecordFile">
+            <Col md={ 7 }>
+                <Row><strong>{ file.name.validValue() }</strong></Row>
+                <TRCell label="File type" value={ file.contentType.validValue() } />
+                <TRCell label="File size" value={ `${ file.size.toString() } (bytes)`} />
+                <TRCell label="Hash" value={ file.hash.toHex() } />
+            </Col>
+            <Col md={ 5 } className="ButtonContainer">
+                <ButtonGroup>
+                    <ViewFileButton
+                        nodeOwner={ loc.ownerAddress }
+                        fileName={ file.name.validValue() }
+                        downloader={ (axios) => getTokensRecordFileSource(axios, {
+                            locId: loc.id.toString(),
+                            recordId: record.id,
+                            hash: file.hash,
+                        }) }
+                    />
+                    <Button
+                        onClick={ () => navigate(documentClaimHistory(viewer, loc, record, file, contributionMode)) }
+                    >
+                        <Icon icon={ { id: "claim" } } /> View document claim history
+                    </Button>
+                </ButtonGroup>
+            </Col>
+        </Row>
+    )
+}
+
+function TRCell(props: { label: string, value: string }) {
+    const { label, value } = props;
+    return (
+        <Row className="TokensRecordFileAttribute">
+            <div>
+                <strong>{ label }</strong>
+                <span className="value">: { value }</span>
+            </div>
+        </Row>
+    )
+}
+
+function documentClaimHistory(viewer: Viewer, loc: LocData, record: TokensRecord, file: UploadableItemFile, contributionMode?: ContributionMode): string {
+    if (viewer === "LegalOfficer") {
+        return tokensRecordDocumentClaimHistoryPath(loc.id, record.id, file.hash);
+    } else if (contributionMode === "Requester") {
+        return requesterTokensRecordDocumentClaimHistoryPath(loc.id, record.id, file.hash);
+    } else if (contributionMode === "VerifiedIssuer") {
+        return issuerTokensRecordDocumentClaimHistoryPath(loc.id, record.id, file.hash);
+    } else {
+        return "";
+    }
+}
+

--- a/src/loc/record/TokensRecordFiles.tsx
+++ b/src/loc/record/TokensRecordFiles.tsx
@@ -15,6 +15,7 @@ import { useNavigate } from "react-router-dom";
 import ButtonGroup from "../../common/ButtonGroup";
 import Col from "react-bootstrap/Col";
 import { Row } from "../../common/Grid";
+import "./TokensRecordFiles.css";
 
 export interface Props {
     record: TokensRecord;

--- a/src/loc/record/TokensRecordTable.css
+++ b/src/loc/record/TokensRecordTable.css
@@ -1,32 +1,3 @@
 .TokensRecordTable .Table.constrained-row-height .body .Row .Col {
     height: 62px;
 }
-
-.TokensRecordTable .TokensRecordFiles {
-    padding: 10px 10px 0 10px;
-    width: 100%;
-}
-
-.TokensRecordTable .TokensRecordFiles .value {
-    font-weight: lighter;
-}
-
-.TokensRecordTable .TokensRecordFiles .TokensRecordFileAttribute {
-    margin-bottom: 0;
-}
-
-.TokensRecordTable .TokensRecordFiles .TokensRecordFile .ButtonGroup {
-    margin-top: 16px;
-    position: relative;
-}
-
-.TokensRecordTable .TokensRecordFiles .TokensRecordFile .btn-group {
-    position: absolute;
-    right: 5px;
-}
-
-.TokensRecordTable .TokensRecordFiles .TokensRecordFile .ButtonGroup .Button {
-    min-width: 58px;
-    margin-left: 5px;
-}
-

--- a/src/loc/record/TokensRecordTable.css
+++ b/src/loc/record/TokensRecordTable.css
@@ -1,3 +1,32 @@
-.TokensRecordTable .ViewFileButton {
-    height: 40px;
+.TokensRecordTable .Table.constrained-row-height .body .Row .Col {
+    height: 62px;
 }
+
+.TokensRecordTable .TokensRecordFiles {
+    padding: 10px 10px 0 10px;
+    width: 100%;
+}
+
+.TokensRecordTable .TokensRecordFiles .value {
+    font-weight: lighter;
+}
+
+.TokensRecordTable .TokensRecordFiles .TokensRecordFileAttribute {
+    margin-bottom: 0;
+}
+
+.TokensRecordTable .TokensRecordFiles .TokensRecordFile .ButtonGroup {
+    margin-top: 16px;
+    position: relative;
+}
+
+.TokensRecordTable .TokensRecordFiles .TokensRecordFile .btn-group {
+    position: absolute;
+    right: 5px;
+}
+
+.TokensRecordTable .TokensRecordFiles .TokensRecordFile .ButtonGroup .Button {
+    min-width: 58px;
+    margin-left: 5px;
+}
+


### PR DESCRIPTION
The actual model of Tokens Records and linked files is better displayed by:
* visually separating record from its files.
* showing all files if requested. 
* providing a decent yet perfectible style sheet - files attributes are styled pretty much like on the certificate.
* adding 2 new buttons under certificate column: copy/paste url and view QR-code.

This PR also implements [these suggestions](https://github.com/logion-network/logion-internal/issues/1155#issuecomment-1985140231).

logion-network/logion-internal#1154
logion-network/logion-internal#1155
logion-network/logion-internal#1158