### PR TITLE
Do not wait for finalization

### DIFF
--- a/src/ExtrinsicSubmissionResult.test.tsx
+++ b/src/ExtrinsicSubmissionResult.test.tsx
@@ -13,23 +13,23 @@ test("No result, error", () => {
     expect(tree).toMatchSnapshot();
 });
 
-test("Non-finalized result, error", () => {
-    const tree = render(<ExtrinsicSubmissionResult result={{isFinalized: false, status: {isFinalized: false}} as SignedTransaction} error={"error"} />);
+test("In progress result, error", () => {
+    const tree = render(<ExtrinsicSubmissionResult result={{isInBlock: false, status: {isInBlock: false}} as SignedTransaction} error={"error"} />);
     expect(tree).toMatchSnapshot();
 });
 
-test("Non-finalized result, no error", () => {
-    const tree = render(<ExtrinsicSubmissionResult result={{isFinalized: false, status: {type: "Ready", isFinalized: false}} as SignedTransaction} error={null} />);
+test("In progress result, no error", () => {
+    const tree = render(<ExtrinsicSubmissionResult result={{isInBlock: false, status: {type: "Ready", isInBlock: false}} as SignedTransaction} error={null} />);
     expect(tree).toMatchSnapshot();
 });
 
-test("Finalized result, no error", () => {
-    const tree = render(<ExtrinsicSubmissionResult result={{isFinalized: true, status: {isFinalized: true}} as SignedTransaction} error={null} />);
+test("Done result, no error", () => {
+    const tree = render(<ExtrinsicSubmissionResult result={{isInBlock: true, status: {isInBlock: true}} as SignedTransaction} error={null} />);
     expect(tree).toMatchSnapshot();
 });
 
-test("Finalized result, no error, custom message", () => {
-    const tree = render(<ExtrinsicSubmissionResult result={{isFinalized: true, status: {isFinalized: true}} as SignedTransaction} error={null} successMessage="Success" />);
+test("Done result, no error, custom message", () => {
+    const tree = render(<ExtrinsicSubmissionResult result={{isInBlock: true, status: {isInBlock: true}} as SignedTransaction} error={null} successMessage="Success" />);
     expect(tree).toMatchSnapshot();
 });
 

--- a/src/ExtrinsicSubmitter.test.tsx
+++ b/src/ExtrinsicSubmitter.test.tsx
@@ -21,8 +21,8 @@ describe("ExtrinsicSubmitter", () => {
         />);
     
         expect(screen.getByRole('generic')).toBeEmptyDOMElement();
-        expect(onSuccess).not.toBeCalled();
-        expect(onError).not.toBeCalled();
+        expect(onSuccess).not.toHaveBeenCalled();
+        expect(onError).not.toHaveBeenCalled();
     });
 
     it("is initially showing submitting", async () => {
@@ -39,8 +39,8 @@ describe("ExtrinsicSubmitter", () => {
         />);
     
         await waitFor(() => expectSubmitting());
-        expect(onSuccess).not.toBeCalled();
-        expect(onError).not.toBeCalled();
+        expect(onSuccess).not.toHaveBeenCalled();
+        expect(onError).not.toHaveBeenCalled();
     });
 
     it("shows error and calls onError", async () => {
@@ -57,8 +57,8 @@ describe("ExtrinsicSubmitter", () => {
         />);
 
         await waitFor(() => expect(screen.getByText("Submission failed: error")).toBeInTheDocument());
-        expect(onSuccess).not.toBeCalled();
-        expect(onError).toBeCalled();
+        expect(onSuccess).not.toHaveBeenCalled();
+        expect(onError).toHaveBeenCalled();
     });
 
     it("shows progress", async () => {
@@ -75,8 +75,8 @@ describe("ExtrinsicSubmitter", () => {
         />);
     
         await waitFor(() => expect(screen.getByText("Current status: undefined")).toBeInTheDocument());
-        expect(onSuccess).not.toBeCalled();
-        expect(onError).not.toBeCalled();
+        expect(onSuccess).not.toHaveBeenCalled();
+        expect(onError).not.toHaveBeenCalled();
     });
 
     it("shows success and calls onSuccess", async () => {
@@ -93,8 +93,8 @@ describe("ExtrinsicSubmitter", () => {
         />);
     
         await waitFor(() => expect(screen.getByText("Submission successful.")).toBeInTheDocument());
-        expect(onSuccess).toBeCalledWith("extrinsicId");
-        expect(onError).not.toBeCalled();
+        expect(onSuccess).toHaveBeenCalledWith("extrinsicId");
+        expect(onError).not.toHaveBeenCalled();
     });
 });
 

--- a/src/__snapshots__/ExtrinsicSubmissionResult.test.tsx.snap
+++ b/src/__snapshots__/ExtrinsicSubmissionResult.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Finalized result, no error 1`] = `
+exports[`Done result, no error 1`] = `
 <div
   className="ExtrinsicSubmissionResult"
 >
@@ -20,7 +20,7 @@ exports[`Finalized result, no error 1`] = `
 </div>
 `;
 
-exports[`Finalized result, no error, custom message 1`] = `
+exports[`Done result, no error, custom message 1`] = `
 <div
   className="ExtrinsicSubmissionResult"
 >
@@ -34,6 +34,49 @@ exports[`Finalized result, no error, custom message 1`] = `
     }
   >
     Success
+  </div>
+</div>
+`;
+
+exports[`In progress result, error 1`] = `
+<div
+  className="ExtrinsicSubmissionResult"
+>
+  <div
+    className="Alert danger"
+    style={
+      Object {
+        "backgroundColor": undefined,
+        "color": "#e11a25",
+      }
+    }
+  >
+    <p>
+      Submission failed: error
+    </p>
+  </div>
+</div>
+`;
+
+exports[`In progress result, no error 1`] = `
+<div
+  className="ExtrinsicSubmissionResult"
+>
+  <div
+    className="Alert polkadot"
+    style={
+      Object {
+        "backgroundColor": "#e6007a",
+        "color": "white",
+      }
+    }
+  >
+    <div
+      className="spinner-border"
+    />
+    <p>
+      Current status: Ready
+    </p>
   </div>
 </div>
 `;
@@ -91,49 +134,6 @@ exports[`No result, no error 1`] = `
   >
     <p>
       Submitting...
-    </p>
-  </div>
-</div>
-`;
-
-exports[`Non-finalized result, error 1`] = `
-<div
-  className="ExtrinsicSubmissionResult"
->
-  <div
-    className="Alert danger"
-    style={
-      Object {
-        "backgroundColor": undefined,
-        "color": "#e11a25",
-      }
-    }
-  >
-    <p>
-      Submission failed: error
-    </p>
-  </div>
-</div>
-`;
-
-exports[`Non-finalized result, no error 1`] = `
-<div
-  className="ExtrinsicSubmissionResult"
->
-  <div
-    className="Alert polkadot"
-    style={
-      Object {
-        "backgroundColor": "#e6007a",
-        "color": "white",
-      }
-    }
-  >
-    <div
-      className="spinner-border"
-    />
-    <p>
-      Current status: Ready
     </p>
   </div>
 </div>

--- a/src/common/PendingVaultTransferRequests.tsx
+++ b/src/common/PendingVaultTransferRequests.tsx
@@ -71,7 +71,7 @@ export default function PendingVaultTransferRequests() {
                     },
                 ]}
                 data={ pendingRequests }
-                renderEmpty={ () => <EmptyTableMessage>No pending vault-out transfers</EmptyTableMessage> }
+                renderEmpty={ () => <EmptyTableMessage>No pending vault withdrawals</EmptyTableMessage> }
             />
             <RequestToCancel
                 requestToCancel={ requestToCancel }

--- a/src/common/RequestToCancel.tsx
+++ b/src/common/RequestToCancel.tsx
@@ -64,9 +64,9 @@ export default function RequestToCancel(props: Props) {
             ]}
             size="lg"
         >
-            <h2>Cancel vault-out transfer</h2>
+            <h2>Cancel vault withdrawal</h2>
 
-            <p>This will cancel the vault-out transfer. Your Legal Officer will be notified.</p>
+            <p>This will cancel the vault withdrawal. Your Legal Officer will be notified.</p>
 
             <ExtrinsicSubmissionStateView />
         </Dialog>

--- a/src/common/__snapshots__/WalletGauge.test.tsx.snap
+++ b/src/common/__snapshots__/WalletGauge.test.tsx.snap
@@ -108,101 +108,99 @@ exports[`WalletGauge renders 1`] = `
     <h3>
       
     </h3>
-    <React.Fragment>
-      <FormGroup
-        colors={
-          Object {
-            "background": "#0c163d",
-            "borderColor": "#e6007a",
-            "foreground": "#ffffff",
-          }
+    <FormGroup
+      colors={
+        Object {
+          "background": "#0c163d",
+          "borderColor": "#e6007a",
+          "foreground": "#ffffff",
         }
-        control={
+      }
+      control={
+        <FormControl
+          isInvalid={false}
+          onChange={[Function]}
+          placeholder="The beneficiary's SS58 address"
+          type="text"
+          value=""
+        />
+      }
+      id="destination"
+      label="Destination"
+    />
+    <FormGroup
+      colors={
+        Object {
+          "background": "#0c163d",
+          "borderColor": "#e6007a",
+          "foreground": "#ffffff",
+        }
+      }
+      control={
+        <InputGroup
+          hasValidation={true}
+        >
           <FormControl
             isInvalid={false}
             onChange={[Function]}
-            placeholder="The beneficiary's SS58 address"
+            placeholder="The amount to transfer"
             type="text"
             value=""
           />
-        }
-        id="destination"
-        label="Destination"
-      />
-      <FormGroup
-        colors={
-          Object {
-            "background": "#0c163d",
-            "borderColor": "#e6007a",
-            "foreground": "#ffffff",
-          }
-        }
-        control={
-          <InputGroup
-            hasValidation={true}
+          <DropdownButton
+            id="input-group-dropdown-1"
+            title="LGNT"
           >
-            <FormControl
-              isInvalid={false}
-              onChange={[Function]}
-              placeholder="The amount to transfer"
-              type="text"
-              value=""
-            />
-            <DropdownButton
-              id="input-group-dropdown-1"
-              title="LGNT"
+            <DropdownItem
+              onClick={[Function]}
             >
-              <DropdownItem
-                onClick={[Function]}
-              >
-                LGNT
-              </DropdownItem>
-              <DropdownItem
-                onClick={[Function]}
-              >
-                mLGNT
-              </DropdownItem>
-              <DropdownItem
-                onClick={[Function]}
-              >
-                µLGNT
-              </DropdownItem>
-              <DropdownItem
-                onClick={[Function]}
-              >
-                nLGNT
-              </DropdownItem>
-              <DropdownItem
-                onClick={[Function]}
-              >
-                pLGNT
-              </DropdownItem>
-              <DropdownItem
-                onClick={[Function]}
-              >
-                fLGNT
-              </DropdownItem>
-              <DropdownItem
-                onClick={[Function]}
-              >
-                aLGNT
-              </DropdownItem>
-            </DropdownButton>
-            <Feedback
-              type="invalid"
+              LGNT
+            </DropdownItem>
+            <DropdownItem
+              onClick={[Function]}
             >
-              Please enter a valid amount.
-            </Feedback>
-          </InputGroup>
-        }
-        id="amount"
-        label="Amount"
-        noFeedback={true}
-      />
-      <ExtrinsicSubmissionStateView
-        successMessage="Transfer successful."
-      />
-    </React.Fragment>
+              mLGNT
+            </DropdownItem>
+            <DropdownItem
+              onClick={[Function]}
+            >
+              µLGNT
+            </DropdownItem>
+            <DropdownItem
+              onClick={[Function]}
+            >
+              nLGNT
+            </DropdownItem>
+            <DropdownItem
+              onClick={[Function]}
+            >
+              pLGNT
+            </DropdownItem>
+            <DropdownItem
+              onClick={[Function]}
+            >
+              fLGNT
+            </DropdownItem>
+            <DropdownItem
+              onClick={[Function]}
+            >
+              aLGNT
+            </DropdownItem>
+          </DropdownButton>
+          <Feedback
+            type="invalid"
+          >
+            Please enter a valid amount.
+          </Feedback>
+        </InputGroup>
+      }
+      id="amount"
+      label="Amount"
+      noFeedback={true}
+    />
+    <ExtrinsicSubmissionStateView
+      successMessage="Transfer successful."
+    />
   </Dialog>
 </div>
 `;

--- a/src/legal-officer/vault/PendingVaultTransferRequests.tsx
+++ b/src/legal-officer/vault/PendingVaultTransferRequests.tsx
@@ -155,7 +155,7 @@ export default function PendingVaultTransferRequests() {
                     },
                 ]}
                 data={ pendingVaultTransferRequests }
-                renderEmpty={ () => <EmptyTableMessage>No pending vault-out transfers</EmptyTableMessage> }
+                renderEmpty={ () => <EmptyTableMessage>No pending vault withdrawals</EmptyTableMessage> }
             />
             <Dialog
                 show={ requestToAccept !== null }
@@ -177,7 +177,7 @@ export default function PendingVaultTransferRequests() {
                 ]}
                 size="xl"
             >
-                <h2>Accepting vault-out transfer</h2>
+                <h2>Accepting vault withdrawal</h2>
 
                 <p>You are about to accept and sign a transfer authorization from the user's Vault.</p>
 
@@ -236,7 +236,7 @@ export default function PendingVaultTransferRequests() {
                 ]}
                 size="lg"
             >
-                <h2>Reject vault-out transfer</h2>
+                <h2>Reject vault withdrawal</h2>
 
                 <FormGroup
                     id="reason"

--- a/src/legal-officer/vault/VaultTransferRequestsHistory.tsx
+++ b/src/legal-officer/vault/VaultTransferRequestsHistory.tsx
@@ -53,7 +53,7 @@ export default function VaultTransferRequestsHistory() {
                     },
                 ]}
                 data={ vaultTransferRequestsHistory }
-                renderEmpty={ () => <EmptyTableMessage>No pending vault-out transfers</EmptyTableMessage> }
+                renderEmpty={ () => <EmptyTableMessage>No pending vault withdrawals</EmptyTableMessage> }
             />
         </>
     );

--- a/src/loc/AcknowledgeButton.tsx
+++ b/src/loc/AcknowledgeButton.tsx
@@ -120,6 +120,7 @@ export default function AcknowledgeButton(props: Props) {
             <Button
                 variant="polkadot"
                 onClick={ preview }
+                disabled={ props.locItem.timestamp === null }
             >
                 <Icon icon={{ id: "shield" }} /> Acknowledge
             </Button>

--- a/src/loc/LocPublishButton.test.tsx
+++ b/src/loc/LocPublishButton.test.tsx
@@ -21,7 +21,7 @@ describe("LocPublishButton", () => {
         const locItem = new MetadataItem(
             {
                 type: "Data",
-                status: "DRAFT",
+                status: "REVIEW_ACCEPTED",
                 submitter: TEST_WALLET_USER,
                 timestamp: null,
                 newItem: false,
@@ -61,7 +61,7 @@ describe("LocPublishButton", () => {
         const locItem = new MetadataItem(
             {
                 type: "Data",
-                status: "DRAFT",
+                status: "REVIEW_ACCEPTED",
                 submitter: TEST_WALLET_USER,
                 timestamp: null,
                 newItem: false,

--- a/src/loc/LocPublishButton.tsx
+++ b/src/loc/LocPublishButton.tsx
@@ -34,7 +34,7 @@ export default function LocPublishButton(props: PublishProps) {
     }, [ submitCall, call ]);
 
     useEffect(() => {
-        if(fees === undefined) {
+        if(fees === undefined && props.locItem.status === "REVIEW_ACCEPTED") {
             setFees(null);
             (async function() {
                 setFees(await props.feesEstimator());

--- a/src/loc/__snapshots__/LocItems.test.tsx.snap
+++ b/src/loc/__snapshots__/LocItems.test.tsx.snap
@@ -327,7 +327,7 @@ exports[`LOLocItems renders with single draft item 1`] = `
                 >
                   <button
                     className="Button btn btn-polkadot"
-                    disabled={false}
+                    disabled={true}
                     onClick={[Function]}
                     style={
                       Object {
@@ -792,7 +792,7 @@ exports[`UserLocItems renders with single draft item 1`] = `
                 >
                   <button
                     className="Button btn btn-polkadot"
-                    disabled={false}
+                    disabled={true}
                     onClick={[Function]}
                     style={
                       Object {

--- a/src/logion-chain/__mocks__/LogionChainMock.ts
+++ b/src/logion-chain/__mocks__/LogionChainMock.ts
@@ -110,13 +110,15 @@ export const SUCCESSFUL_SUBMISSION: unknown = {
     getError: () => null,
     getResult: () => ({
         status: {
-            isFinalized: true,
-        }
+            isInBlock: true,
+        },
+        isInBlock: true,
     }),
     result: {
         status: {
-            isFinalized: true,
-        }
+            isInBlock: true,
+        },
+        isInBlock: true,
     },
     callEnded: true,
     submitted: true,
@@ -131,12 +133,12 @@ export const FAILED_SUBMISSION: unknown = {
     getError: () => "error",
     getResult: () => ({
         status: {
-            isFinalized: false,
+            isInBlock: false,
         }
     }),
     result: {
         status: {
-            isFinalized: false,
+            isInBlock: false,
         }
     },
     callEnded: true,
@@ -152,12 +154,12 @@ export const PENDING_SUBMISSION: unknown = {
     getError: () => null,
     getResult: () => ({
         status: {
-            isFinalized: false,
+            isInBlock: false,
         }
     }),
     result: {
         status: {
-            isFinalized: false,
+            isInBlock: false,
         }
     },
 };

--- a/src/logion-chain/__mocks__/SignatureMock.tsx
+++ b/src/logion-chain/__mocks__/SignatureMock.tsx
@@ -19,7 +19,7 @@ export function resetSubmitting() {
 }
 
 export function finalizeSubmission() {
-    signAndSendCallback!(mockSubmittableResult(true, "finalized"));
+    signAndSendCallback!(mockSubmittableResult(true, "isInBlock"));
 }
 
 export function failSubmission() {
@@ -30,11 +30,11 @@ export function setSignAndSend(fn: any) {
     signAndSend = fn;
 }
 
-export function mockSubmittableResult(isFinalized: boolean, statusType?: string, isError?: boolean): ISubmittableResult {
+export function mockSubmittableResult(isInBlock: boolean, statusType?: string, isError?: boolean): ISubmittableResult {
     const result: unknown = {
-        isFinalized,
+        isInBlock,
         status: {
-            isFinalized,
+            isInBlock,
             type: statusType,
             asInBlock: {
                 toString: () => "some-hex"


### PR DESCRIPTION
* Wait for in-block instead of finalization.
* Prevents acknowledgment if no timestamp (i.e. not yet synced backend-side).
* Close is already safe (cannot close if acknowledgement not yet synced, check in the SDK).
* Fixes bug about estimating fees when not relevant (threw an error in LLO UI, potentially with no impact in production but visible with development mode).
* Do not wait for transaction after successful LGNT transfer (but show a message telling there is a delay before it shows up in history). The logic in the context can be removed later.

logion-network/logion-internal#1222