### PR TITLE
Properly clear submission state after open and void

### DIFF
--- a/src/common/RequestToCancel.tsx
+++ b/src/common/RequestToCancel.tsx
@@ -38,6 +38,8 @@ export default function RequestToCancel(props: Props) {
         try {
             await submitCall(call);
             close();
+        } catch(e) {
+            console.log(e);
         } finally {
             clearSubmissionState();
         }

--- a/src/legal-officer/recovery/RecoveryDetails.tsx
+++ b/src/legal-officer/recovery/RecoveryDetails.tsx
@@ -88,6 +88,8 @@ export default function RecoveryDetails() {
                 await submitCall(call);
                 refreshRequests!(false);
                 navigate(RECOVERY_REQUESTS_PATH);
+            } catch(e) {
+                console.log(e);
             } finally {
                 clearSubmissionState();
             }

--- a/src/legal-officer/vault/PendingVaultTransferRequests.tsx
+++ b/src/legal-officer/vault/PendingVaultTransferRequests.tsx
@@ -68,6 +68,8 @@ export default function PendingVaultTransferRequests() {
         try {
             await submitCall(call);
             onApprovalSuccessCallback();
+        } catch(e) {
+            console.log(e);
         } finally {
             clearSubmissionState();
         }

--- a/src/loc/ContextualizedLocDetails.tsx
+++ b/src/loc/ContextualizedLocDetails.tsx
@@ -13,6 +13,7 @@ import VoidFrame from "./VoidFrame";
 import AcceptRejectLocRequest from "./AcceptRejectLocRequest";
 import { locRequestsPath } from "src/legal-officer/LegalOfficerPaths";
 import { ReadOnlyLocState } from "@logion/client";
+import BlockNone from "src/components/blocknone/BlockNone";
 
 export default function ContextualizedLocDetails() {
     const {
@@ -89,12 +90,13 @@ export default function ContextualizedLocDetails() {
                 context={ loc.locType + " LOC" }
                 checkedItem="confidential document"
             />
-            {
-                (loc.status === "OPEN" || loc.status === "CLOSED") && !isReadOnly &&
+            <BlockNone
+                show={ (loc.status === "OPEN" || loc.status === "CLOSED") && !isReadOnly && loc.voidInfo === undefined }
+            >
                 <VoidFrame
                     loc={ loc }
                 />
-            }
+            </BlockNone>
         </LocPane>
     );
 }

--- a/src/loc/LocPublishButton.tsx
+++ b/src/loc/LocPublishButton.tsx
@@ -28,6 +28,8 @@ export default function LocPublishButton(props: PublishProps) {
         setPublishState({ status: PublishStatus.PUBLISHING });
         try {
             await submitCall(call);
+        } catch(e) {
+            console.log(e);
         } finally {
             setPublishState({ status: PublishStatus.DONE });
         }

--- a/src/loc/OpenLoc.tsx
+++ b/src/loc/OpenLoc.tsx
@@ -26,7 +26,7 @@ export interface Props {
 }
 
 export default function OpenLoc(props: Props) {
-    const { signer, client, submitCall } = useLogionChain();
+    const { signer, client, submitCall, clearSubmissionState } = useLogionChain();
     const { refresh } = useCommonContext();
     const { mutateLocState, locState } = useLocContext();
     const [ acceptState, setAcceptState ] = useState<OpenStatus>(OpenStatus.NONE);
@@ -69,6 +69,8 @@ export default function OpenLoc(props: Props) {
         setAcceptState(OpenStatus.CREATING_LOC);
         try {
             await submitCall(openLoc);
+        } catch(e) {
+            console.log(e);
         } finally {
             setAcceptState(OpenStatus.CREATED_OR_ERROR);
         }
@@ -78,8 +80,9 @@ export default function OpenLoc(props: Props) {
     ]);
 
     const close = useCallback(() => {
+        clearSubmissionState();
         setAcceptState(OpenStatus.NONE);
-    }, []);
+    }, [ clearSubmissionState ]);
 
     const closeAndRefresh = useCallback(() => {
         close();

--- a/src/loc/RestricedDeliveryCell.tsx
+++ b/src/loc/RestricedDeliveryCell.tsx
@@ -39,6 +39,8 @@ export default function RestrictedDeliveryCell(props: Props) {
                     return current;
                 }
             });
+        } catch(e) {
+            console.log(e);
         } finally {
             setDisabled(false);
         }

--- a/src/loc/UserContextualizedLocDetails.tsx
+++ b/src/loc/UserContextualizedLocDetails.tsx
@@ -16,6 +16,7 @@ import { useMemo } from 'react';
 import IdenfyVerification from './IdenfyVerification';
 import { ReadOnlyLocState } from '@logion/client';
 import OpenLoc from './OpenLoc';
+import BlockNone from 'src/components/blocknone/BlockNone';
 
 export interface Props {
     contributionMode: ContributionMode;
@@ -79,12 +80,13 @@ export default function UserContextualizedLocDetails(props: Props) {
                 legalOfficer={ getOfficer(loc.ownerAccountId) }
                 contributionMode={ props.contributionMode }
             />
-            {
-                loc.status === "REVIEW_ACCEPTED" &&
+            <BlockNone
+                show={ loc.status === "REVIEW_ACCEPTED" }
+            >
                 <OpenLoc
                     loc={ loc }
                 />
-            }
+            </BlockNone>
             {
                 (loc.status === "OPEN" || loc.status === "CLOSED") &&
                 <>

--- a/src/loc/VoidFrame.test.tsx
+++ b/src/loc/VoidFrame.test.tsx
@@ -4,15 +4,6 @@ import VoidFrame from "./VoidFrame";
 
 describe("VoidFrame", () => {
 
-    it("renders empty if already void", () => {
-        const loc = {
-            voidInfo: {
-
-            }
-        } as unknown as LocData;
-        renderWithLoc(loc);
-    })
-
     it("renders for non-void non-collection LOC", () => {
         const loc = {
             locType: "Transaction",

--- a/src/loc/VoidFrame.tsx
+++ b/src/loc/VoidFrame.tsx
@@ -15,10 +15,6 @@ export interface Props {
 export default function VoidFrame(props: Props) {
     const { loc } = props;
 
-    if(loc.voidInfo) {
-        return null;
-    }
-
     return (
         <DangerFrame
             className="VoidFrame"

--- a/src/loc/VoidLocButton.test.tsx
+++ b/src/loc/VoidLocButton.test.tsx
@@ -46,10 +46,10 @@ describe("VoidLocButton", () => {
         // await waitFor(() => expect(dialog!).not.toBeVisible());
     });
 
-    it("disappears on cancel", async () => {
+    it("disappears on close", async () => {
         const dialog = await renderAndOpenDialog();
 
-        await clickByName("Cancel");
+        await clickByName("Close");
 
         await waitFor(() => expect(dialog!).not.toBeVisible());
     });

--- a/src/loc/VoidLocButton.tsx
+++ b/src/loc/VoidLocButton.tsx
@@ -58,8 +58,8 @@ export default function VoidLocButton() {
                 size="lg"
                 actions={[
                     {
-                        id: "cancel",
-                        buttonText: "Cancel",
+                        id: "close",
+                        buttonText: "Close",
                         buttonVariant: "danger-outline",
                         callback: clearAndClose,
                         disabled: extrinsicSubmissionState.submitted && !extrinsicSubmissionState.callEnded

--- a/src/loc/VoidLocReplaceExistingButton.test.tsx
+++ b/src/loc/VoidLocReplaceExistingButton.test.tsx
@@ -4,13 +4,11 @@ import userEvent from "@testing-library/user-event";
 
 import { clickByName, typeByLabel } from "src/tests";
 import VoidLocReplaceExistingButton from "./VoidLocReplaceExistingButton";
-import { expectSubmitting, setupQueriesGetLegalOfficerCase } from "src/test/Util";
+import { setupQueriesGetLegalOfficerCase } from "src/test/Util";
 import { UUID } from "@logion/node-api";
 import { setupApiMock, OPEN_IDENTITY_LOC, OPEN_IDENTITY_LOC_ID } from "src/__mocks__/LogionMock";
-import { mockSubmittableResult } from "src/logion-chain/__mocks__/SignatureMock";
 import { OpenLoc } from "src/__mocks__/LogionClientMock";
 import { setLocState } from "./__mocks__/LocContextMock";
-import { SUCCESSFUL_SUBMISSION, setExtrinsicSubmissionState } from "src/logion-chain/__mocks__/LogionChainMock";
 
 jest.mock("../common/CommonContext");
 jest.mock("./LocContext");
@@ -50,10 +48,10 @@ describe("VoidLocReplaceExistingButton", () => {
 
     });
 
-    it("disappears on cancel", async () => {
+    it("disappears on close", async () => {
         const dialog = await renderAndOpenDialog();
 
-        await clickByName("Cancel");
+        await clickByName("Close");
 
         await waitFor(() => expect(dialog!).not.toBeVisible());
     });

--- a/src/loc/VoidLocReplaceExistingButton.tsx
+++ b/src/loc/VoidLocReplaceExistingButton.tsx
@@ -88,8 +88,8 @@ export default function VoidLocReplaceExistingButton() {
                 size="lg"
                 actions={[
                     {
-                        id: "cancel",
-                        buttonText: "Cancel",
+                        id: "close",
+                        buttonText: "Close",
                         buttonVariant: "danger-outline",
                         callback: clearAndClose
                     },

--- a/src/loc/__snapshots__/ContextualizedLocDetails.test.tsx.snap
+++ b/src/loc/__snapshots__/ContextualizedLocDetails.test.tsx.snap
@@ -411,70 +411,74 @@ exports[`ContextualizedLocDetails renders 1`] = `
     checkedItem="confidential document"
     context="Identity LOC"
   />
-  <VoidFrame
-    loc={
-      Object {
-        "createdOn": "2023-10-10T08:25:18.546Z",
-        "decisionOn": "2023-10-10T08:25:18.546Z",
-        "description": "Description",
-        "fees": Object {
-          "collectionItemFee": Lgnt {
-            "canonical": 0n,
+  <BlockNone
+    show={true}
+  >
+    <VoidFrame
+      loc={
+        Object {
+          "createdOn": "2023-10-10T08:25:18.546Z",
+          "decisionOn": "2023-10-10T08:25:18.546Z",
+          "description": "Description",
+          "fees": Object {
+            "collectionItemFee": Lgnt {
+              "canonical": 0n,
+            },
+            "legalFee": Lgnt {
+              "canonical": 0n,
+            },
+            "tokensRecordFee": Lgnt {
+              "canonical": 0n,
+            },
+            "valueFee": Lgnt {
+              "canonical": 0n,
+            },
           },
-          "legalFee": Lgnt {
-            "canonical": 0n,
+          "files": Array [],
+          "id": UUID {
+            "bytes": Array [
+              147,
+              99,
+              195,
+              214,
+              209,
+              7,
+              66,
+              26,
+              164,
+              75,
+              133,
+              199,
+              250,
+              176,
+              184,
+              67,
+            ],
           },
-          "tokensRecordFee": Lgnt {
-            "canonical": 0n,
+          "invitedContributors": Array [],
+          "issuers": Array [],
+          "links": Array [],
+          "locType": "Identity",
+          "metadata": Array [],
+          "ownerAccountId": ValidAccountId {
+            "anyAccountId": AnyAccountId {
+              "address": "vQx5kESPn8dWyX4KxMCKqUyCaWUwtui1isX6PVNcZh2Ghjitr",
+              "type": "Polkadot",
+            },
           },
-          "valueFee": Lgnt {
-            "canonical": 0n,
+          "requesterAccountId": ValidAccountId {
+            "anyAccountId": AnyAccountId {
+              "address": "vQv9qfqLY88pF4poNh6XpvUpxC9MAdcwLjVma8LMcyMYFff5h",
+              "type": "Polkadot",
+            },
           },
-        },
-        "files": Array [],
-        "id": UUID {
-          "bytes": Array [
-            147,
-            99,
-            195,
-            214,
-            209,
-            7,
-            66,
-            26,
-            164,
-            75,
-            133,
-            199,
-            250,
-            176,
-            184,
-            67,
-          ],
-        },
-        "invitedContributors": Array [],
-        "issuers": Array [],
-        "links": Array [],
-        "locType": "Identity",
-        "metadata": Array [],
-        "ownerAccountId": ValidAccountId {
-          "anyAccountId": AnyAccountId {
-            "address": "vQx5kESPn8dWyX4KxMCKqUyCaWUwtui1isX6PVNcZh2Ghjitr",
-            "type": "Polkadot",
-          },
-        },
-        "requesterAccountId": ValidAccountId {
-          "anyAccountId": AnyAccountId {
-            "address": "vQv9qfqLY88pF4poNh6XpvUpxC9MAdcwLjVma8LMcyMYFff5h",
-            "type": "Polkadot",
-          },
-        },
-        "requesterLocId": undefined,
-        "status": "OPEN",
-        "verifiedIssuer": false,
+          "requesterLocId": undefined,
+          "status": "OPEN",
+          "verifiedIssuer": false,
+        }
       }
-    }
-  />
+    />
+  </BlockNone>
 </LocPane>
 `;
 
@@ -739,5 +743,48 @@ exports[`ContextualizedLocDetails renders empty 1`] = `
     checkedItem="confidential document"
     context="Identity LOC"
   />
+  <BlockNone
+    show={false}
+  >
+    <VoidFrame
+      loc={
+        Object {
+          "id": UUID {
+            "bytes": Uint8Array [
+              174,
+              212,
+              198,
+              228,
+              151,
+              158,
+              72,
+              173,
+              190,
+              110,
+              75,
+              211,
+              159,
+              185,
+              71,
+              98,
+            ],
+          },
+          "locType": "Identity",
+          "requesterAccountId": ValidAccountId {
+            "anyAccountId": AnyAccountId {
+              "address": "vQv9qfqLY88pF4poNh6XpvUpxC9MAdcwLjVma8LMcyMYFff5h",
+              "type": "Polkadot",
+            },
+          },
+          "userIdentity": Object {
+            "email": "john.doe@logion.network",
+            "firstName": "John",
+            "lastName": "Doe",
+            "phoneNumber": "+1234",
+          },
+        }
+      }
+    />
+  </BlockNone>
 </LocPane>
 `;

--- a/src/loc/__snapshots__/UserContextualizedLocDetails.test.tsx.snap
+++ b/src/loc/__snapshots__/UserContextualizedLocDetails.test.tsx.snap
@@ -167,6 +167,74 @@ exports[`UserContextualizedLocDetails renders for requester 1`] = `
     locItems={Array []}
     viewer="User"
   />
+  <BlockNone
+    show={false}
+  >
+    <OpenLoc
+      loc={
+        Object {
+          "createdOn": "2023-10-10T08:25:18.546Z",
+          "decisionOn": "2023-10-10T08:25:18.546Z",
+          "description": "Description",
+          "fees": Object {
+            "collectionItemFee": Lgnt {
+              "canonical": 0n,
+            },
+            "legalFee": Lgnt {
+              "canonical": 0n,
+            },
+            "tokensRecordFee": Lgnt {
+              "canonical": 0n,
+            },
+            "valueFee": Lgnt {
+              "canonical": 0n,
+            },
+          },
+          "files": Array [],
+          "id": UUID {
+            "bytes": Array [
+              147,
+              99,
+              195,
+              214,
+              209,
+              7,
+              66,
+              26,
+              164,
+              75,
+              133,
+              199,
+              250,
+              176,
+              184,
+              67,
+            ],
+          },
+          "invitedContributors": Array [],
+          "issuers": Array [],
+          "links": Array [],
+          "locType": "Identity",
+          "metadata": Array [],
+          "ownerAccountId": ValidAccountId {
+            "anyAccountId": AnyAccountId {
+              "address": "vQx5kESPn8dWyX4KxMCKqUyCaWUwtui1isX6PVNcZh2Ghjitr",
+              "type": "Polkadot",
+            },
+          },
+          "requesterAccountId": ValidAccountId {
+            "anyAccountId": AnyAccountId {
+              "address": "vQv9qfqLY88pF4poNh6XpvUpxC9MAdcwLjVma8LMcyMYFff5h",
+              "type": "Polkadot",
+            },
+          },
+          "requesterLocId": undefined,
+          "status": "OPEN",
+          "verifiedIssuer": false,
+        }
+      }
+    />
+  </BlockNone>
   <React.Fragment>
     <VoidDisclaimer
       loc={
@@ -540,6 +608,74 @@ exports[`UserContextualizedLocDetails renders for verified issuer 1`] = `
     locItems={Array []}
     viewer="User"
   />
+  <BlockNone
+    show={false}
+  >
+    <OpenLoc
+      loc={
+        Object {
+          "createdOn": "2023-10-10T08:25:18.546Z",
+          "decisionOn": "2023-10-10T08:25:18.546Z",
+          "description": "Description",
+          "fees": Object {
+            "collectionItemFee": Lgnt {
+              "canonical": 0n,
+            },
+            "legalFee": Lgnt {
+              "canonical": 0n,
+            },
+            "tokensRecordFee": Lgnt {
+              "canonical": 0n,
+            },
+            "valueFee": Lgnt {
+              "canonical": 0n,
+            },
+          },
+          "files": Array [],
+          "id": UUID {
+            "bytes": Array [
+              147,
+              99,
+              195,
+              214,
+              209,
+              7,
+              66,
+              26,
+              164,
+              75,
+              133,
+              199,
+              250,
+              176,
+              184,
+              67,
+            ],
+          },
+          "invitedContributors": Array [],
+          "issuers": Array [],
+          "links": Array [],
+          "locType": "Identity",
+          "metadata": Array [],
+          "ownerAccountId": ValidAccountId {
+            "anyAccountId": AnyAccountId {
+              "address": "vQx5kESPn8dWyX4KxMCKqUyCaWUwtui1isX6PVNcZh2Ghjitr",
+              "type": "Polkadot",
+            },
+          },
+          "requesterAccountId": ValidAccountId {
+            "anyAccountId": AnyAccountId {
+              "address": "vQv9qfqLY88pF4poNh6XpvUpxC9MAdcwLjVma8LMcyMYFff5h",
+              "type": "Polkadot",
+            },
+          },
+          "requesterLocId": undefined,
+          "status": "OPEN",
+          "verifiedIssuer": false,
+        }
+      }
+    />
+  </BlockNone>
   <React.Fragment>
     <VoidDisclaimer
       loc={

--- a/src/loc/__snapshots__/VoidFrame.test.tsx.snap
+++ b/src/loc/__snapshots__/VoidFrame.test.tsx.snap
@@ -1,7 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`VoidFrame renders empty if already void 1`] = `null`;
-
 exports[`VoidFrame renders for non-void collection LOC (only void without replacer) 1`] = `
 <DangerFrame
   className="VoidFrame"

--- a/src/settings/ValuesFiles.tsx
+++ b/src/settings/ValuesFiles.tsx
@@ -34,6 +34,8 @@ export function ValuesFiles() {
                 file: HashOrContent.fromContent(new BrowserFile(file, file.name)),
                 fileId
             });
+        } catch(e) {
+            console.log(e);
         } finally {
             setUploading({
                 ...uploading,

--- a/src/vault/VaultOutRequest.tsx
+++ b/src/vault/VaultOutRequest.tsx
@@ -76,6 +76,8 @@ export default function VaultOutRequest() {
         try {
             await submitCall(call);
             close();
+        } catch(e) {
+            console.log(e);
         } finally {
             clearSubmissionState();
         }

--- a/src/wallet-user/protection/CreateProtectionRequestForm.tsx
+++ b/src/wallet-user/protection/CreateProtectionRequestForm.tsx
@@ -79,6 +79,8 @@ export default function CreateProtectionRequestForm(props: Props) {
 
         try {
             await submitCall(call);
+        } catch(e) {
+            console.log(e);
         } finally {
             clearSubmissionState();
         }

--- a/src/wallet-user/protection/ProtectionRecoveryRequest.tsx
+++ b/src/wallet-user/protection/ProtectionRecoveryRequest.tsx
@@ -43,6 +43,8 @@ export default function ProtectionRecoveryRequest(props: Props) {
     const activateProtectionCallback = useCallback(async () => {
         try {
             await submitCall(activateProtection!);
+        } catch(e) {
+            console.log(e);
         } finally {
             clearSubmissionState();
         }
@@ -51,6 +53,8 @@ export default function ProtectionRecoveryRequest(props: Props) {
     const claimRecoveryCallback = useCallback(async () => {
         try {
             await submitCall(claimRecovery!);
+        } catch(e) {
+            console.log(e);
         } finally {
             clearSubmissionState();
         }


### PR DESCRIPTION
* Do not destroy component (open and void buttons) so that user can click on button triggering the submission state clearing.
* Systematically catch all errors thrown by `await submitCall(call)`.

logion-network/logion-internal#1134
logion-network/logion-internal#1194