### PR TITLE
Add secret recovery request form

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "react-date-picker": "^9.1.0",
     "react-dev-utils": "^12.0.1",
     "react-dom": "^18.2.0",
-    "react-hook-form": "^7.39.1",
+    "react-hook-form": "^7.51.4",
     "react-refresh": "^0.11.0",
     "react-responsive": "^9.0.0",
     "react-router-dom": "^6.4.3",

--- a/src/Login.css
+++ b/src/Login.css
@@ -1,5 +1,5 @@
 .Login {
-    height: 100vh;
+    min-height: 100vh;
     background: linear-gradient(0deg, #9f1278 0%, #3b6cf4 100%);
     display: flex;
     position: relative;
@@ -65,23 +65,12 @@
     margin-right: 10px;
 }
 
-.Login .node-info {
+.Login .recovery-container {
     text-align: center;
-    margin-bottom: 60px;
-}
-
-.Login .node-info .name {
-    font-size: 1.2rem;
-    font-weight: bold;
-}
-
-.Login .node-info .peer-id {
-    font-size: 0.9rem;
-    font-weight: bold;
-}
-
-.Login .node-info .peer-id img {
-    margin-right: 10px;
+    position: relative;
+    z-index: 1;
+    padding-top: 3rem;
+    padding-bottom: 2rem;
 }
 
 .Login .left-character {

--- a/src/Login.tsx
+++ b/src/Login.tsx
@@ -13,6 +13,7 @@ import AbsoluteLogo from './AbsoluteLogo';
 import './Login.css';
 import Icon from "./common/Icon";
 import Alert from "./common/Alert";
+import { SECRET_RECOVERY_PATH } from "./PublicPaths";
 
 export const LOGIN_PATH = "/login";
 
@@ -129,12 +130,14 @@ export default function Login() {
                     </Button>
                 </div>
 
-                <div className="node-info">
-                    <p className="name">You are currently connected to the following logion node:</p>
-                    <p className="peer-id">
-                        <img src={process.env.PUBLIC_URL + "/assets/node.svg"} alt="node icon" />
-                        Peer ID: {connectedNodeMetadata.peerId}
-                    </p>
+                <div className="recovery-container">
+                    <h2>Do you need to recover a secret?</h2>
+
+                    <Button
+                        onClick={ () => navigate(SECRET_RECOVERY_PATH) }
+                    >
+                       Recover a secret
+                    </Button>
                 </div>
             </Container>
             <div className="left-character">

--- a/src/PublicPaths.tsx
+++ b/src/PublicPaths.tsx
@@ -51,3 +51,6 @@ export function fullTokensRecordsCertificate(locId: UUID, recordId: Hash, noRedi
 export function getBaseUrl(): string {
     return `${ window.location.protocol }//${ window.location.host }`;
 }
+
+export const SECRET_RECOVERY_RELATIVE_PATH = "/secret-recovery";
+export const SECRET_RECOVERY_PATH = PUBLIC_PATH + SECRET_RECOVERY_RELATIVE_PATH;

--- a/src/PublicRouter.tsx
+++ b/src/PublicRouter.tsx
@@ -3,8 +3,10 @@ import Certificate from "./certificate/Certificate";
 import {
     CERTIFICATE_RELATIVE_PATH,
     COLLECTION_ITEM_CERTIFICATE_RELATIVE_PATH,
+    SECRET_RECOVERY_RELATIVE_PATH,
     TOKENS_RECORD_CERTIFICATE_RELATIVE_PATH
 } from "./PublicPaths";
+import SecretRecoveryRequestFormPage from "./pages/public/secretrecoveryrequest/SecretRecoveryRequestFormPage";
 
 export default function PublicRouter() {
     return (
@@ -14,6 +16,7 @@ export default function PublicRouter() {
                 <Route path={ COLLECTION_ITEM_CERTIFICATE_RELATIVE_PATH } element={ <Certificate /> } />
                 <Route path={ TOKENS_RECORD_CERTIFICATE_RELATIVE_PATH } element={ <Certificate /> } />
             </Route>
+            <Route path={ SECRET_RECOVERY_RELATIVE_PATH } element={ <SecretRecoveryRequestFormPage /> } />
         </Routes>
     )
 }

--- a/src/__snapshots__/Login.test.tsx.snap
+++ b/src/__snapshots__/Login.test.tsx.snap
@@ -87,22 +87,16 @@ exports[`Login renders 1`] = `
       </Button>
     </div>
     <div
-      className="node-info"
+      className="recovery-container"
     >
-      <p
-        className="name"
+      <h2>
+        Do you need to recover a secret?
+      </h2>
+      <Button
+        onClick={[Function]}
       >
-        You are currently connected to the following logion node:
-      </p>
-      <p
-        className="peer-id"
-      >
-        <img
-          alt="node icon"
-          src="/assets/node.svg"
-        />
-        Peer ID: 
-      </p>
+        Recover a secret
+      </Button>
     </div>
   </Container>
   <div

--- a/src/components/identity/IdentityForm.tsx
+++ b/src/components/identity/IdentityForm.tsx
@@ -126,7 +126,6 @@ export default function IdentityForm(props: Props) {
                 </Col>
             </Row>
 
-            <h3>Address</h3>
             <FormGroup
                 id="line1"
                 label="Line1"

--- a/src/landing/LandingPage.css
+++ b/src/landing/LandingPage.css
@@ -269,6 +269,7 @@
     display: block;
     top: -87px;
     right: 0;
+    z-index: -1;
 }
 
 .LandingPage .recovery-container .recovery-process {
@@ -290,6 +291,15 @@
 
 .LandingPage .recovery-container .recovery-process .Button.btn.btn-primary:focus {
     box-shadow: none;
+}
+
+.LandingPage .recovery-buttons {
+    display: flex;
+    justify-content: center;
+}
+
+.LandingPage .recovery-buttons :nth-child(n+2) {
+    margin-left: 20px;
 }
 
 .LandingPage .protection-container {

--- a/src/landing/LandingPage.tsx
+++ b/src/landing/LandingPage.tsx
@@ -2,6 +2,7 @@ import { useCallback, useState } from 'react';
 import Container from 'react-bootstrap/Container';
 import Row from 'react-bootstrap/Row';
 import Col from 'react-bootstrap/Col';
+import { useNavigate } from 'react-router-dom';
 
 import Button from '../common/Button';
 import Dialog from '../common/Dialog';
@@ -12,6 +13,7 @@ import AbsoluteLogo from '../AbsoluteLogo';
 import './LandingPage.css';
 import { Tutorial } from './Tutorial';
 import { useLogionChain } from '../logion-chain';
+import { SECRET_RECOVERY_PATH } from 'src/PublicPaths';
 
 export interface Props {
     activeStep: Step,
@@ -24,6 +26,7 @@ type DialogType = 'install' | 'create' | 'recover' | null;
 export default function LandingPage(props: Props) {
     const { tryEnableMetaMask } = useLogionChain();
     const [ showDialog, setShowDialog ] = useState<DialogType>(null);
+    const navigate = useNavigate();
 
     let stepsLeft;
     if(props.activeStep === 'install') {
@@ -170,7 +173,10 @@ export default function LandingPage(props: Props) {
                                     Inaccessible wallet?&nbsp;
                                     <strong>recovery process</strong>
                                 </p>
-                                <Button onClick={ () => setShowDialog("recover") }>Start my recovery process</Button>
+                                <div className="recovery-buttons">
+                                    <Button onClick={ () => setShowDialog("recover") }>Start my recovery process</Button>
+                                    <Button onClick={ () => navigate(SECRET_RECOVERY_PATH) }>Request secret recovery</Button>
+                                </div>
                                 <Dialog
                                     actions={[
                                         {

--- a/src/landing/__snapshots__/LandingPage.test.tsx.snap
+++ b/src/landing/__snapshots__/LandingPage.test.tsx.snap
@@ -304,11 +304,20 @@ exports[`renders create 1`] = `
                 recovery process
               </strong>
             </p>
-            <Button
-              onClick={[Function]}
+            <div
+              className="recovery-buttons"
             >
-              Start my recovery process
-            </Button>
+              <Button
+                onClick={[Function]}
+              >
+                Start my recovery process
+              </Button>
+              <Button
+                onClick={[Function]}
+              >
+                Request secret recovery
+              </Button>
+            </div>
             <Dialog
               actions={
                 Array [
@@ -851,11 +860,20 @@ exports[`renders install 1`] = `
                 recovery process
               </strong>
             </p>
-            <Button
-              onClick={[Function]}
+            <div
+              className="recovery-buttons"
             >
-              Start my recovery process
-            </Button>
+              <Button
+                onClick={[Function]}
+              >
+                Start my recovery process
+              </Button>
+              <Button
+                onClick={[Function]}
+              >
+                Request secret recovery
+              </Button>
+            </div>
             <Dialog
               actions={
                 Array [

--- a/src/loc/__snapshots__/IdentityLocRequest.test.tsx.snap
+++ b/src/loc/__snapshots__/IdentityLocRequest.test.tsx.snap
@@ -156,13 +156,15 @@ exports[`IdentityLocRequest renders 1`] = `
             control={
               Object {
                 "_defaultValues": Object {},
+                "_disableForm": [Function],
                 "_executeSchema": [Function],
                 "_fields": Object {},
-                "_focusError": [Function],
                 "_formState": Object {
                   "dirtyFields": Object {},
+                  "disabled": false,
                   "errors": Object {},
                   "isDirty": false,
+                  "isLoading": false,
                   "isSubmitSuccessful": false,
                   "isSubmitted": false,
                   "isSubmitting": false,
@@ -170,6 +172,7 @@ exports[`IdentityLocRequest renders 1`] = `
                   "isValidating": false,
                   "submitCount": 0,
                   "touchedFields": Object {},
+                  "validatingFields": Object {},
                 },
                 "_formValues": Object {},
                 "_getDirty": [Function],
@@ -193,9 +196,13 @@ exports[`IdentityLocRequest renders 1`] = `
                   "isValid": false,
                   "isValidating": false,
                   "touchedFields": false,
+                  "validatingFields": false,
                 },
                 "_removeUnmounted": [Function],
-                "_stateFlags": Object {
+                "_reset": [Function],
+                "_resetDefaultValues": [Function],
+                "_setErrors": [Function],
+                "_state": Object {
                   "action": false,
                   "mount": false,
                   "watch": false,
@@ -213,17 +220,21 @@ exports[`IdentityLocRequest renders 1`] = `
                     "subscribe": [Function],
                     "unsubscribe": [Function],
                   },
-                  "watch": Object {
+                  "values": Object {
                     "next": [Function],
                     "observers": Array [],
                     "subscribe": [Function],
                     "unsubscribe": [Function],
                   },
                 },
+                "_updateDisabledField": [Function],
                 "_updateFieldArray": [Function],
+                "_updateFormState": [Function],
                 "_updateValid": [Function],
                 "getFieldState": [Function],
+                "handleSubmit": [Function],
                 "register": [Function],
+                "setError": [Function],
                 "unregister": [Function],
               }
             }

--- a/src/pages/public/secretrecoveryrequest/SecretRecoveryRequestForm.tsx
+++ b/src/pages/public/secretrecoveryrequest/SecretRecoveryRequestForm.tsx
@@ -1,0 +1,118 @@
+import { UUID } from "@logion/node-api";
+import { useCallback } from "react";
+import { Form } from "react-bootstrap";
+import { Control, Controller, FieldErrors, UseFormSetValue } from "react-hook-form";
+import Button from "src/common/Button";
+import { BackgroundAndForegroundColors } from "src/common/ColorTheme";
+import FormGroup from "src/common/FormGroup";
+import { useLogionChain } from "src/logion-chain";
+
+export interface FormValues {
+    locId: string;
+    secretName: string;
+    challenge: string;
+}
+
+export interface Props {
+    control: Control<FormValues>;
+    errors: FieldErrors<FormValues>;
+    colors: BackgroundAndForegroundColors;
+    setValue: UseFormSetValue<FormValues>;
+}
+
+export default function SecretRecoveryRequestForm(props: Props) {
+    const { control, errors, colors, setValue } = props;
+    const { client } = useLogionChain();
+
+    const validateLocId = useCallback(async (locIdString: string) => {
+        const locId = UUID.fromAnyString(locIdString);
+        if(locId === undefined) {
+            return "Invalid LOC ID";
+        }
+        if(client) {
+            const loc = await client?.public.findLocById({ locId });
+            if(loc === undefined) {
+                return "LOC not found";
+            }
+            if(loc.data.locType !== "Identity") {
+                return "LOC is not an Identity LOC";
+            }
+            if(loc.data.status !== "CLOSED") {
+                return "LOC is not closed";
+            }
+        }
+    }, [ client ]);
+
+    return (
+        <div className="SecretRecoveryRequestForm">
+            <FormGroup
+                id="locId"
+                label="Identity LOC ID"
+                control={
+                    <Controller
+                        name="locId"
+                        control={ control }
+                        defaultValue=""
+                        rules={ { validate: validateLocId } }
+                        render={ ({ field }) => (
+                            <Form.Control
+                                isInvalid={ !!errors.locId?.message }
+                                type="text"
+                                { ...field }
+                            />
+                        ) }
+                    />
+                }
+                feedback={ errors.locId?.message }
+                colors={ colors }
+            />
+            <FormGroup
+                id="secretName"
+                label="Secret name"
+                control={
+                    <Controller
+                        name="secretName"
+                        control={ control }
+                        defaultValue=""
+                        rules={ { required: "Secret name is required" } }
+                        render={ ({ field }) => (
+                            <Form.Control
+                                isInvalid={ !!errors.secretName?.message }
+                                type="text"
+                                { ...field }
+                            />
+                        ) }
+                    />
+                }
+                feedback={ errors.secretName?.message }
+                colors={ colors }
+            />
+            <FormGroup
+                id="challenge"
+                label="Challenge"
+                control={
+                    <Controller
+                        name="challenge"
+                        control={ control }
+                        defaultValue=""
+                        rules={ { required: "A challenge is required" } }
+                        render={ ({ field }) => (
+                            <Form.Control
+                                isInvalid={ !!errors.challenge?.message }
+                                type="text"
+                                { ...field }
+                            />
+                        ) }
+                    />
+                }
+                feedback={ errors.challenge?.message }
+                colors={ colors }
+            />
+
+            <p>The challenge is a random value that is attached to your request. <strong>You will have to provide it again
+                upon actual secret retrieval. Make sure to keep it in a safe place until the procedure is over.</strong></p>
+
+            <Button onClick={ () => setValue("challenge", window.crypto.randomUUID()) }>Generate random challenge</Button>
+        </div>
+    );
+}

--- a/src/pages/public/secretrecoveryrequest/SecretRecoveryRequestFormPage.css
+++ b/src/pages/public/secretrecoveryrequest/SecretRecoveryRequestFormPage.css
@@ -1,0 +1,33 @@
+.SecretRecoveryRequestFormPage {
+    background-color: #0c163d;
+    padding-top: 30px;
+    padding-bottom: 30px;
+    min-height: 100vh;
+}
+
+.SecretRecoveryRequestFormPage .container > .row {
+    margin-bottom: 30px;
+}
+
+.SecretRecoveryRequestFormPage .container > .row:last-child {
+    margin-bottom: 0;
+}
+
+.SecretRecoveryRequestFormPage .alert-container {
+    display: flex;
+    justify-content: center;
+}
+
+.SecretRecoveryRequestFormPage .success-frame {
+    text-align: center;
+}
+
+.SecretRecoveryRequestFormPage .success-icon {
+    margin-bottom: 30px;
+}
+
+.SecretRecoveryRequestFormPage .challenge {
+    text-align: center;
+    font-weight: bold;
+    font-size: 1.5rem;
+}

--- a/src/pages/public/secretrecoveryrequest/SecretRecoveryRequestFormPage.test.tsx
+++ b/src/pages/public/secretrecoveryrequest/SecretRecoveryRequestFormPage.test.tsx
@@ -1,0 +1,118 @@
+import { LocRequestStatus, LogionClient, PublicLoc } from '@logion/client';
+import { UUID, LocType } from "@logion/node-api";
+import { screen, render, waitFor } from '@testing-library/react';
+import SecretRecoveryRequestFormPage from './SecretRecoveryRequestFormPage';
+import { clickByName, typeByLabel } from 'src/tests';
+import { setClientMock } from 'src/logion-chain/__mocks__/LogionChainMock';
+
+jest.mock("src/logion-chain");
+
+describe("SecretRecoveryRequestFormPage", () => {
+
+    it("shows success message", async () => {
+        setClientMock(mockClient(LOC_ID, {
+            locType: "Identity",
+            status: "CLOSED",
+        }));
+        render(<SecretRecoveryRequestFormPage />);
+        await fillInSecretRecoveryRequestForm();
+        await fillInIdentityForm();
+
+        await clickByName("Submit");
+
+        await waitFor(() => expect(screen.queryByText("Submission successful")).toBeInTheDocument());
+        expect(screen.queryByText(LOC_ID.toDecimalString())).toBeInTheDocument();
+        expect(screen.queryByText(SECRET_NAME)).toBeInTheDocument();
+        expect(screen.queryByText(CHALLENGE)).toBeInTheDocument();
+        expect(screen.queryByRole("button", { name: "Submit" })).not.toBeInTheDocument();
+    });
+
+    it("prevents submission if missing data", async () => {
+        render(<SecretRecoveryRequestFormPage />);
+        await clickByName("Submit");
+        await waitFor(() => expect(screen.queryByText("Some information above is not valid")).toBeInTheDocument());
+    });
+
+    it("prevents submission if LOC not found", async () => {
+        setClientMock(mockClient(new UUID(), {
+            locType: "Identity",
+            status: "CLOSED",
+        }));
+        render(<SecretRecoveryRequestFormPage />);
+        await fillInSecretRecoveryRequestForm();
+        await fillInIdentityForm();
+
+        await clickByName("Submit");
+
+        await waitFor(() => expect(screen.queryByText("Some information above is not valid")).toBeInTheDocument());
+        expect(screen.queryByText("LOC not found")).toBeInTheDocument();
+    });
+
+    it("prevents submission if not identity LOC", async () => {
+        setClientMock(mockClient(LOC_ID, {
+            locType: "Collection",
+            status: "CLOSED",
+        }));
+        render(<SecretRecoveryRequestFormPage />);
+        await fillInSecretRecoveryRequestForm();
+        await fillInIdentityForm();
+
+        await clickByName("Submit");
+
+        await waitFor(() => expect(screen.queryByText("Some information above is not valid")).toBeInTheDocument());
+        expect(screen.queryByText("LOC is not an Identity LOC")).toBeInTheDocument();
+    });
+
+    it("prevents submission if identity LOC not closed", async () => {
+        setClientMock(mockClient(LOC_ID, {
+            locType: "Identity",
+            status: "OPEN",
+        }));
+        render(<SecretRecoveryRequestFormPage />);
+        await fillInSecretRecoveryRequestForm();
+        await fillInIdentityForm();
+
+        await clickByName("Submit");
+
+        await waitFor(() => expect(screen.queryByText("Some information above is not valid")).toBeInTheDocument());
+        expect(screen.queryByText("LOC is not closed")).toBeInTheDocument();
+    });
+});
+
+function mockClient(expectedLocId: UUID, data: { locType: LocType, status: LocRequestStatus }) {
+    return {
+        public: {
+            findLocById: (args: { locId: UUID }) => {
+                if(args.locId.equalTo(expectedLocId)) {
+                    return Promise.resolve({
+                        data,
+                    } as PublicLoc);
+                } else {
+                    return Promise.resolve(undefined);
+                }
+            }
+        }
+    } as unknown as LogionClient;
+}
+
+const LOC_ID = new UUID();
+const SECRET_NAME = "Key";
+const CHALLENGE = "Some random challenge";
+
+async function fillInSecretRecoveryRequestForm() {
+    await typeByLabel("Identity LOC ID", LOC_ID.toDecimalString());
+    await typeByLabel("Secret name", SECRET_NAME);
+    await typeByLabel("Challenge", CHALLENGE);
+}
+
+async function fillInIdentityForm() {
+    await typeByLabel("First Name", "John");
+    await typeByLabel("Last Name", "Doe");
+    await typeByLabel("Email", "john@logion.network");
+    await typeByLabel("Phone Number", "+1234");
+
+    await typeByLabel("Line1", "?");
+    await typeByLabel("Postal Code", "?");
+    await typeByLabel("City", "?");
+    await typeByLabel("Country", "?");
+}

--- a/src/pages/public/secretrecoveryrequest/SecretRecoveryRequestFormPage.tsx
+++ b/src/pages/public/secretrecoveryrequest/SecretRecoveryRequestFormPage.tsx
@@ -1,0 +1,119 @@
+import { Col, Container, Row } from "react-bootstrap";
+import { useForm } from "react-hook-form";
+import { useCommonContext } from "src/common/CommonContext";
+import Frame from "src/common/Frame";
+import IdentityForm, { FormValues as IdentityFormValues } from "src/components/identity/IdentityForm";
+
+import "./SecretRecoveryRequestFormPage.css";
+import SecretRecoveryRequestForm, { FormValues as SecretFormValues } from "./SecretRecoveryRequestForm";
+import ButtonGroup from "src/common/ButtonGroup";
+import Button from "src/common/Button";
+import { useCallback, useState } from "react";
+import Alert from "src/common/Alert";
+import Icon from "src/common/Icon";
+import CopyPasteButton from "src/common/CopyPasteButton";
+
+export default function SecretRecoveryRequestFormPage() {
+    const { colorTheme } = useCommonContext();
+    const { control: secretControl, trigger: secretTrigger, formState: { errors: secretErrors }, setValue, getValues } = useForm<SecretFormValues>();
+    const { control: identityControl, trigger: identityTrigger, formState: { errors: identityErrors } } = useForm<IdentityFormValues>();
+    const [ error, setError ] = useState<string>();
+    const [ submitting, setSubmitting ] = useState(false);
+    const [ submitted, setSubmitted ] = useState(false);
+
+    const submit = useCallback(async () => {
+        setError(undefined);
+        setSubmitting(true);
+        setSubmitted(false);
+        const results = await Promise.all([ secretTrigger(), identityTrigger() ]);
+        const formError = !(results[0] && results[1]);
+        if(formError) {
+            setError("Some information above is not valid");
+        } else {
+            try {
+                // TODO: actually submit data
+                setSubmitted(true);
+            } catch(e) {
+                if(e instanceof Error) {
+                    setError(e.message);
+                } else {
+                    setError("" + e);
+                }
+            }
+        }
+        setSubmitting(false);
+    }, [ secretTrigger, identityTrigger ]);
+
+    return (
+        <div className="SecretRecoveryRequestFormPage">
+            {
+                !submitted &&
+                <Container>
+                    <Row>
+                        <Col>
+                            <Frame
+                                title="Secret to recover"
+                            >
+                                <p>The information below can be found in an e-mail you received after
+                                    creating the recoverable secret.</p>
+                                <SecretRecoveryRequestForm
+                                    control={ secretControl }
+                                    errors={ secretErrors }
+                                    colors={ colorTheme.frame }
+                                    setValue={ setValue }
+                                />
+                            </Frame>
+                        </Col>
+                    </Row>
+                    <Row>
+                        <Col>
+                            <Frame
+                                title="Personal information"
+                            >
+                                <p>The information below must match what you provided in the Identity LOC
+                                    mentioned in the above frame.</p>
+                                <IdentityForm
+                                    control={ identityControl }
+                                    errors={ identityErrors }
+                                    colors={ colorTheme.frame }
+                                />
+                            </Frame>
+                        </Col>
+                    </Row>
+                    <Row>
+                        <ButtonGroup>
+                            <Button onClick={ submit } disabled={ submitting }>Submit</Button>
+                        </ButtonGroup>
+                        {
+                            error !== undefined &&
+                            <div className="alert-container">
+                                <Alert variant="danger">{ error }</Alert>
+                            </div>
+                        }
+                    </Row>
+                </Container>
+            }
+            {
+                submitted &&
+                <Container>
+                    <Row>
+                        <Col>
+                            <Frame
+                                title="Submission successful"
+                                className="success-frame"
+                            >
+                                <p className="success-icon"><Icon icon={{ id: "ok" }} height="64"/></p>
+                                <p>Your request to recover secret <strong>{ getValues().secretName }</strong>{" "}
+                                    from LOC <strong>{ getValues().locId }</strong>{" "}
+                                    has been submitted successfully.</p>
+                                <p><strong>Please keep below challenge in a safe place, you will need it in order
+                                    to retrieve the secret once your request has been approved</strong>:</p>
+                                <p className="challenge">{ getValues().challenge } <CopyPasteButton value={ getValues().challenge } /></p>
+                            </Frame>
+                        </Col>
+                    </Row>
+                </Container>
+            }
+        </div>
+    );
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -12185,7 +12185,7 @@ __metadata:
     react-date-picker: ^9.1.0
     react-dev-utils: ^12.0.1
     react-dom: ^18.2.0
-    react-hook-form: ^7.39.1
+    react-hook-form: ^7.51.4
     react-refresh: ^0.11.0
     react-responsive: ^9.0.0
     react-router-dom: ^6.4.3
@@ -14968,12 +14968,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-hook-form@npm:^7.39.1":
-  version: 7.39.1
-  resolution: "react-hook-form@npm:7.39.1"
+"react-hook-form@npm:^7.51.4":
+  version: 7.51.4
+  resolution: "react-hook-form@npm:7.51.4"
   peerDependencies:
     react: ^16.8.0 || ^17 || ^18
-  checksum: 5a5a5530451c337f0366ceb7884b376cc20dec4b667789cd9aab4a9e6c8286308449bd6ba03bd89096541a81051c83307c8b45cd90970fa3c7ffc58ef2e3da78
+  checksum: b3587c23425025cc4ab9d4de71420aeb9b28809a9183691584ecbbf5bb3d85ab8c232afb01424efed11a761c9c726521a230d4e092c7ad6bb70a011a7ba0acf7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
* Secret recovery request page is public i.e. does not require authentication.
* The page is reachable from landing page (no extension enabled) or login page (with any extension enabled).
* Actual data submission to backend is not yet implemented.

logion-network/logion-internal#1257