### PR TITLE
Enable full-draft mode

### DIFF
--- a/src/loc/DataLocRequest.test.tsx
+++ b/src/loc/DataLocRequest.test.tsx
@@ -79,7 +79,7 @@ async function checkFormDisabled() {
     });
 }
 
-function setupLocsState(legalOfficersWithValidIdentityLoc: LegalOfficerClass[]) {
+function setupLocsState(legalOfficersWithNonVoidIdentityLoc: LegalOfficerClass[]) {
     const draftRequest = {
         locId,
         locsState: () => locsState,
@@ -88,7 +88,7 @@ function setupLocsState(legalOfficersWithValidIdentityLoc: LegalOfficerClass[]) 
         }),
     } as DraftRequest;
     const locsState = {
-        legalOfficersWithValidIdentityLoc,
+        legalOfficersWithNonVoidIdentityLoc,
         requestTransactionLoc: () => Promise.resolve(draftRequest),
         requestCollectionLoc: () => Promise.resolve(draftRequest),
     } as unknown as LocsState;

--- a/src/loc/DataLocRequest.tsx
+++ b/src/loc/DataLocRequest.tsx
@@ -25,9 +25,9 @@ export default function DataLocRequest(props: Props) {
     const [ legalOfficer, setLegalOfficer ] = useState<LegalOfficerClass | null>(null);
     const { locsState } = useUserContext();
     const navigate = useNavigate();
-    const legalOfficersWithValidIdentityLoc = useMemo(() => {
+    const legalOfficersWithNonVoidIdentityLoc = useMemo(() => {
         if (locsState !== undefined) {
-            return locsState.legalOfficersWithValidIdentityLoc
+            return locsState.legalOfficersWithNonVoidIdentityLoc
         } else {
             return []
         }
@@ -42,12 +42,12 @@ export default function DataLocRequest(props: Props) {
         >
             <Row>
                 <Col md={ 6 }>
-                    { legalOfficersWithValidIdentityLoc.length > 0 &&
+                    { legalOfficersWithNonVoidIdentityLoc.length > 0 &&
                         <Frame>
                             <SelectLegalOfficer
                                 legalOfficer={ legalOfficer }
                                 legalOfficerNumber={ 1 }
-                                legalOfficers={ legalOfficersWithValidIdentityLoc }
+                                legalOfficers={ legalOfficersWithNonVoidIdentityLoc }
                                 mode="select"
                                 otherLegalOfficer={ null }
                                 setLegalOfficer={ setLegalOfficer }
@@ -57,7 +57,7 @@ export default function DataLocRequest(props: Props) {
                             />
                         </Frame>
                     }
-                    { legalOfficersWithValidIdentityLoc.length > 0 &&
+                    { legalOfficersWithNonVoidIdentityLoc.length > 0 &&
                         <Frame className="request-additional-id-loc-frame">
                             <p className="info-text">If you do not see the Logion Legal officer you are looking for,
                                 please request an Identity LOC to the Logion Legal Officer of your choice by
@@ -67,7 +67,7 @@ export default function DataLocRequest(props: Props) {
                             </ButtonGroup>
                         </Frame>
                     }
-                    { legalOfficersWithValidIdentityLoc.length === 0 &&
+                    { legalOfficersWithNonVoidIdentityLoc.length === 0 &&
                         <Frame className="request-id-loc-frame">
                             <p className="info-text">To submit a { locType } LOC request, you must select a Logion Legal
                                 Officer who already executed an Identity LOC linked to your Polkadot address.</p>

--- a/src/loc/DraftLocInstructions.tsx
+++ b/src/loc/DraftLocInstructions.tsx
@@ -32,6 +32,16 @@ export default function DraftLocInstructions(props: Props) {
                                         <li>Public data will be publicly available on the logion blockchain and public certificate.</li>
                                         <li>Confidential documents will not be publicly available and will stay confidential between you and your Legal Officer.</li>
                                     </ul>
+                                    {
+                                        props.locType !== "Identity" &&
+                                        <p>You must have a valid Identity LOC In order to submit this LOC for review.{" "}
+                                            Also, if your LOC contains a link, its target must be closed and not void.</p>
+                                    }
+                                    <p>You won't be able to cancel this request if it is the target of a link in another request.</p>
+                                    {
+                                        props.locType === "Identity" &&
+                                        <p>You won't be able to cancel this request as long as other requests rely on it.</p>
+                                    }
                                 </>
                             }
                         />

--- a/src/loc/LocDetailsTab.test.tsx
+++ b/src/loc/LocDetailsTab.test.tsx
@@ -182,6 +182,7 @@ function buildLocMock(params: MockParameters): { loc: LocData, locState: LocRequ
         closed: params.status === "CLOSED",
         createdOn,
         closedOn: params.status === "CLOSED" ? closedOn : undefined,
+        links: [],
     } as unknown as LocData;
 
     if(params.voidLoc) {
@@ -190,10 +191,49 @@ function buildLocMock(params: MockParameters): { loc: LocData, locState: LocRequ
         };
     }
 
-    const locState = {
+    const locsState = {
+        draftRequests: {
+            Collection: [],
+            Identity: [],
+            Transaction: [],
+        },
+        openLocs: {
+            Collection: [],
+            Identity: [],
+            Transaction: [],
+        },
+        closedLocs: {
+            Collection: [],
+            Identity: [],
+            Transaction: [],
+        },
+        voidedLocs: {
+            Collection: [],
+            Identity: [],
+            Transaction: [],
+        },
+        pendingRequests: {
+            Collection: [],
+            Identity: [],
+            Transaction: [],
+        },
+        rejectedRequests: {
+            Collection: [],
+            Identity: [],
+            Transaction: [],
+        },
+        acceptedRequests: {
+            Collection: [],
+            Identity: [],
+            Transaction: [],
+        },
+    };
 
+    const locState = {
         isLogionIdentity: () => params.isLogionIdentityLoc === true,
         isLogionData: () => params.locType === "Collection" || params.locType === "Transaction",
+        locsState: () => locsState,
+        data: () => loc,
     } as unknown as LocRequestState;
 
     return { loc, locState };

--- a/src/loc/LocLinkButton.test.tsx
+++ b/src/loc/LocLinkButton.test.tsx
@@ -2,11 +2,12 @@ import LocLinkButton from "./LocLinkButton";
 import { clickByName, shallowRender, typeByLabel } from "../tests";
 import { render, screen, waitFor } from "@testing-library/react";
 import { setClientMock } from "src/logion-chain/__mocks__/LogionChainMock";
-import { LocsState, LogionClient } from "@logion/client";
+import { LogionClient } from "@logion/client";
 import { buildLocRequest } from "./TestData";
 import { UUID } from "@logion/node-api";
 import { setupQueriesGetLegalOfficerCase } from "src/test/Util";
 import { setupApiMock, api, OPEN_IDENTITY_LOC, OPEN_IDENTITY_LOC_ID } from "src/__mocks__/LogionMock";
+import { setLocState } from "./__mocks__/LocContextMock";
 
 jest.mock("./LocContext");
 jest.mock("../logion-chain");
@@ -21,16 +22,20 @@ describe("LocLinkButton", () => {
     })
 
     it("links to an existing LOC", async () => {
+        const locsState = {
+            findByIdOrUndefined: () => ({
+                data: () => buildLocRequest(UUID.fromDecimalStringOrThrow(OPEN_IDENTITY_LOC_ID), OPEN_IDENTITY_LOC),
+            }),
+        };
         setClientMock({
-            locsState: () => Promise.resolve({
-                findById: () => ({
-                    data: () => buildLocRequest(UUID.fromDecimalStringOrThrow(OPEN_IDENTITY_LOC_ID), OPEN_IDENTITY_LOC),
-                }),
-            }) as unknown as LocsState,
+            locsState: () => Promise.resolve(locsState),
             logionApi: api.object(),
         } as unknown as LogionClient);
         setupApiMock(api => {
             setupQueriesGetLegalOfficerCase(api, UUID.fromDecimalStringOrThrow(OPEN_IDENTITY_LOC_ID), OPEN_IDENTITY_LOC);
+        });
+        setLocState({
+            locsState: () => locsState,
         });
 
         render(<LocLinkButton text="Link to an existing LOC"/>);

--- a/src/loc/LocLinkExistingLocDialog.tsx
+++ b/src/loc/LocLinkExistingLocDialog.tsx
@@ -17,8 +17,8 @@ export interface Props {
 }
 
 export default function LocLinkExistingDialog(props: Props) {
-    const { api, client } = useLogionChain();
-    const { mutateLocState, locItems } = useLocContext();
+    const { client } = useLogionChain();
+    const { mutateLocState, locItems, locState } = useLocContext();
     const { control, handleSubmit, setError, clearErrors, formState: { errors }, reset } = useForm<FormValues>({
         defaultValues: {
             locId: ""
@@ -32,9 +32,9 @@ export default function LocLinkExistingDialog(props: Props) {
             setError("locId", { type: "value", message: "Invalid LOC ID" })
             return
         }
-        const loc = await api!.queries.getLegalOfficerCase(locId);
+        const loc = locState?.locsState().findByIdOrUndefined(locId);
         if (!loc) {
-            setError("locId", { type: "value", message: "LOC not found on chain" })
+            setError("locId", { type: "value", message: "LOC not found" })
             return
         }
         const alreadyLinked = locItems.find(item => item.type === 'Linked LOC' && item.as<LinkData>().linkedLoc.id.toString() === locId.toString())
@@ -55,7 +55,7 @@ export default function LocLinkExistingDialog(props: Props) {
         });
         reset();
         props.exit();
-    }, [ props, locItems, api, setError, clearErrors, reset, client, mutateLocState ])
+    }, [ props, locItems, locState, setError, clearErrors, reset, client, mutateLocState ])
 
     return (
         <>

--- a/src/loc/__snapshots__/DraftLocInstructions.test.tsx.snap
+++ b/src/loc/__snapshots__/DraftLocInstructions.test.tsx.snap
@@ -36,6 +36,14 @@ exports[`DraftLocInstructions renders 1`] = `
                   Confidential documents will not be publicly available and will stay confidential between you and your Legal Officer.
                 </li>
               </ul>
+              <p>
+                You must have a valid Identity LOC In order to submit this LOC for review.
+                 
+                Also, if your LOC contains a link, its target must be closed and not void.
+              </p>
+              <p>
+                You won't be able to cancel this request if it is the target of a link in another request.
+              </p>
             </React.Fragment>
           }
         />

--- a/src/loc/__snapshots__/LocDetailsTab.test.tsx.snap
+++ b/src/loc/__snapshots__/LocDetailsTab.test.tsx.snap
@@ -301,6 +301,7 @@ exports[`LocDetailsTabContent renders closed data LOC for LO 1`] = `
                 14,
               ],
             },
+            "links": Array [],
             "locType": "Transaction",
             "status": "CLOSED",
           }
@@ -344,6 +345,7 @@ exports[`LocDetailsTabContent renders closed data LOC for LO 1`] = `
               14,
             ],
           },
+          "links": Array [],
           "locType": "Transaction",
           "status": "CLOSED",
         }
@@ -549,6 +551,7 @@ exports[`LocDetailsTabContent renders closed data LOC for User 1`] = `
                 14,
               ],
             },
+            "links": Array [],
             "locType": "Transaction",
             "status": "CLOSED",
           }
@@ -592,6 +595,7 @@ exports[`LocDetailsTabContent renders closed data LOC for User 1`] = `
               14,
             ],
           },
+          "links": Array [],
           "locType": "Transaction",
           "status": "CLOSED",
         }
@@ -790,6 +794,7 @@ exports[`LocDetailsTabContent renders open data LOC for LO 1`] = `
                 14,
               ],
             },
+            "links": Array [],
             "locType": "Transaction",
             "status": "OPEN",
           }
@@ -833,6 +838,7 @@ exports[`LocDetailsTabContent renders open data LOC for LO 1`] = `
               14,
             ],
           },
+          "links": Array [],
           "locType": "Transaction",
           "status": "OPEN",
         }
@@ -1044,6 +1050,7 @@ exports[`LocDetailsTabContent renders open data LOC for User 1`] = `
                 14,
               ],
             },
+            "links": Array [],
             "locType": "Transaction",
             "status": "OPEN",
           }
@@ -1087,6 +1094,7 @@ exports[`LocDetailsTabContent renders open data LOC for User 1`] = `
               14,
             ],
           },
+          "links": Array [],
           "locType": "Transaction",
           "status": "OPEN",
         }
@@ -1299,6 +1307,7 @@ exports[`LocDetailsTabContent renders open identity LOC for LO 1`] = `
                 14,
               ],
             },
+            "links": Array [],
             "locType": "Identity",
             "status": "OPEN",
           }
@@ -1342,6 +1351,7 @@ exports[`LocDetailsTabContent renders open identity LOC for LO 1`] = `
               14,
             ],
           },
+          "links": Array [],
           "locType": "Identity",
           "status": "OPEN",
         }
@@ -1553,6 +1563,7 @@ exports[`LocDetailsTabContent renders void data LOC for LO 1`] = `
                 14,
               ],
             },
+            "links": Array [],
             "locType": "Transaction",
             "status": "OPEN",
             "voidInfo": Object {},
@@ -1597,6 +1608,7 @@ exports[`LocDetailsTabContent renders void data LOC for LO 1`] = `
               14,
             ],
           },
+          "links": Array [],
           "locType": "Transaction",
           "status": "OPEN",
           "voidInfo": Object {},
@@ -1793,6 +1805,7 @@ exports[`LocDetailsTabContent renders void data LOC for User 1`] = `
                 14,
               ],
             },
+            "links": Array [],
             "locType": "Transaction",
             "status": "OPEN",
             "voidInfo": Object {},
@@ -1837,6 +1850,7 @@ exports[`LocDetailsTabContent renders void data LOC for User 1`] = `
               14,
             ],
           },
+          "links": Array [],
           "locType": "Transaction",
           "status": "OPEN",
           "voidInfo": Object {},


### PR DESCRIPTION
* The user can now create draft data LOCs attached to a draft Identity LOC (i.e. the Identity LOC does not have to be closed anymore).
* Links can target draft LOCs (i.e. they do not have to be on-chain anymore).
* Draft request submission is only possible when Identity LOC is closed and all links target closed LOCs.
* Draft request cancellation is only possible if no incoming links exist and, if an Identity LOC, no other LOCs are attached to it.

logion-network/logion-internal#1318